### PR TITLE
fix: use new path to attach sub issue

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,38 +13,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { owner, repo } = context.repo;
-            const parentIssueNumber = context.payload.issue.number;
-
-            // Fetch repository and parent issue details
-            const { repository } = await github.graphql(`
-              query($owner: String!, $repo: String!, $issueNumber: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  id
-                  issue(number: $issueNumber) {
-                    id
-                  }
-                }
-              }
-            `, { owner, repo, issueNumber: parentIssueNumber });
-
-            const repositoryId = repository.id;
+            const parentIssue = context.issue;
+            const parentIssueTitle = context.payload.issue.title;
+            const parentIssueNumber = parentIssue.number;
 
             // Create the sub-issue
-            const { createIssue } = await github.graphql(`
-              mutation($repositoryId: ID!, $title: String!, $body: String!) {
-                createIssue(input: {repositoryId: $repositoryId, title: $title, body: $body}) {
-                  issue {
-                    id
-                    number
-                  }
-                }
-              }
-            `, {
-              repositoryId,
-              title: "Backport #" + parentIssueNumber + " to release/v0",
-              body:  "Backport #" + parentIssueNumber + " to release/v0"
+            const newIssue = await github.rest.issues.create({
+              owner: parentIssue.owner,
+              repo: parentIssue.repo,
+              title: `Backport #" + parentIssueNumber + " to release/v0`,
+              body: `"Backport #" + parentIssueNumber + " to release/v0`
             });
 
-            // const subIssueId = createIssue.issue.id;
-            // const subIssueNumber = createIssue.issue.number;
+            const subIssueId = newIssue.data.id;
+
+            // Attach the sub-issue to the parent
+            await github.rest.issues.addSubIssue({
+              owner: parentIssue.owner,
+              repo: parentIssue.repo,
+              issue_number: parentIssueNumber,
+              sub_issue_id: subIssueId
+            });


### PR DESCRIPTION
## Related Issue

If this PR will target main,
please complete the below sentence and add labels for each version this should be released to.

Addresses #5  (main issue)
This should be backported to release/v0 (comma separated list of target release branches)

## Description

This change attaches the newly created issue to the parent issue properly.

## Testing

This is a change to a GitHub action, there is no good way to reliably test action code besides Actionlint, which I have run.
