### PR TITLE
fix: add console line to see context

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            console.log("The full event context:", JSON.stringify(context, null, 2));
+
             const parentIssue = context.issue;
             const parentIssueTitle = context.payload.issue.title;
             const parentIssueNumber = parentIssue.number;
@@ -23,8 +25,8 @@ jobs:
             const newIssue = await github.rest.issues.create({
               owner: owner,
               repo: repo,
-              title: `Backport #" + parentIssueNumber + " to release/v0`,
-              body: `"Backport #" + parentIssueNumber + " to release/v0`
+              title: "Backport #" + parentIssueNumber + " to release/v0",
+              body:  "Backport #" + parentIssueNumber + " to release/v0"
             });
 
             const subIssueId = newIssue.data.id;


### PR DESCRIPTION
## Related Issue

If this PR will target main,
please complete the below sentence and add labels for each version this should be released to.

Addresses #5  (main issue)
This should be backported to release/v0, release/v1 (comma separated list of target release branches)

## Description

This adds a console log to see the context. I am attempting to troubleshoot the missing parentIssueNumber in the current version.

## Testing

This is GitHub workflow change, I have run action-lint, but there is not much else possible.
