### PR TITLE
fix: use rest request to get sub issues

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -34,7 +34,6 @@ jobs:
               repo,
               commit_sha: mergeCommitSha,
             });
-
             const pr = associatedPrs.find(p => p.base.ref === 'main' && p.merged_at);
             if (!pr) {
               core.info(`No merged PR found for commit ${mergeCommitSha}. This may have been a direct push. Exiting.`);
@@ -46,7 +45,6 @@ jobs:
             const searchResults = await github.rest.search.issuesAndPullRequests({
               q: `is:issue label:"internal/main" repo:${owner}/${repo} in:body #${pr.number}`
             });
-
             if (searchResults.data.items.length === 0) {
               core.info(`No 'internal/main' issue found for PR #${pr.number}. Exiting.`);
               return;
@@ -55,12 +53,14 @@ jobs:
             core.info(`Found main issue: #${mainIssue.number}`);
 
             core.info(`Fetching sub-issues for main issue #${mainIssue.number}`);
-            const { data: subIssues } = await github.rest.issues.listSubIssues({
-              owner,
-              repo,
+            const { data: subIssues } = await github.request('GET /repos/{owner}/{repo}/issues/{issue_number}/sub-issues', {
+              owner: owner,
+              repo: repo,
               issue_number: mainIssue.number,
+              headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
             });
-
             if (subIssues.length === 0) {
               core.info(`No sub-issues found for issue #${mainIssue.number}. Exiting.`);
               return;
@@ -77,8 +77,8 @@ jobs:
                 continue;
               }
               const targetBranch = releaseLabel.name
-              core.info(`Processing sub-issue #${subIssueNumber} for target branch: ${targetBranch}`);
 
+              core.info(`Processing sub-issue #${subIssueNumber} for target branch: ${targetBranch}`);
               const newBranchName = `backport-${pr.number}-${targetBranch.replace(/\//g, '-')}`;
               execSync(`git config user.name "github-actions[bot]"`);
               execSync(`git config user.email "github-actions[bot]@users.noreply.github.com"`);


### PR DESCRIPTION
## Related Issue

If this PR will target main, please correct the below sentence.

Addresses #5  (main issue)

## Releases
none

## Description

This change uses the REST API to get the sub-issues rather the octokit SDK.

## Testing

actionlint
