### PR TITLE
fix: use new search API and handle empty label

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -42,7 +42,7 @@ jobs:
             core.info(`Found associated PR: #${pr.number}`);
 
             core.info(`Searching for 'internal/main' issue linked to PR #${pr.number}`);
-            const searchResults = await github.rest.search.issuesAndPullRequests({
+            const searchResults = await github.rest.search.issues({
               q: `is:issue label:"internal/main" repo:${owner}/${repo} in:body #${pr.number}`
             });
             if (searchResults.data.items.length === 0) {

--- a/.github/workflows/main-issue.yml
+++ b/.github/workflows/main-issue.yml
@@ -19,7 +19,11 @@ jobs:
             const owner = context.repo.owner;
             const pr = context.payload.pull_request;
             const releaseLabel = pr.head.labels.find(label => label.name.startsWith('release/v'));
-            const versionLabel = releaseLabel.name.replace('release/', 'version/');
+            if releaseLabel {
+              const versionLabel = releaseLabel.name.replace('release/', 'version/');
+            } else {
+              const versionLabel = ''
+            }
 
             // Create the main issue
             const newIssue = await github.rest.issues.create({


### PR DESCRIPTION
## Related Issue

If this PR will target main, please correct the below sentence.

Addresses #5  (main issue)

## Releases

none

## Description

This uses the new issue search API, the previous one is deprecated and will be removed in Sept.
It also handles the occasion where the PR isn't labeled.

## Testing

actionlint
