### PR TITLE
fix: remove backport info from pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 ## Related Issue
 
-If this PR will target main, please correct the below sentence.
-
 Addresses #1234 (main issue)
 
 ## Releases
@@ -22,10 +20,3 @@ Please describe how you verified this change or why testing isn't relevant.
 Does this change alter an interface that users of the provider will need to adjust to?
 Will there be any existing configurations broken by this change?
 
-## Backport
-
-Is this a cherry-picked backport from the default branch?
-If so, please delete all other sections and complete the sentence below:
-
-Cherry-pick #1236 (main PR) to release/v1 (release branch)
-Addresses #1235 (backport issue) for #1234 (main issue)

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755113249,
-        "narHash": "sha256-/bIVS2iP5mixEQWsaiiJ7EGLtk5Id9OehWbmTbzN6kE=",
+        "lastModified": 1755577059,
+        "narHash": "sha256-5hYhxIpco8xR+IpP3uU56+4+Bw7mf7EMyxS/HqUYHQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9e0d35e5f735bf3d1e96815272f46fe7083232c",
+        "rev": "97eb7ee0da337d385ab015a23e15022c865be75c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Related Issue

Addresses #5 (main issue)

## Releases

none

## Description

This updates the PR template, removing the backport lines.

## Testing

actionlint
