### PR TITLE
fix: use API directly to query issues

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -42,8 +42,9 @@ jobs:
             core.info(`Found associated PR: #${pr.number}`);
 
             core.info(`Searching for 'internal/main' issue linked to PR #${pr.number}`);
-            const searchResults = await github.rest.search.issues({
-              q: `is:issue label:"internal/main" repo:${owner}/${repo} in:body #${pr.number}`
+            const { data: searchResults } = await github.request('GET /search/issues', {
+              q: `is:issue label:"internal/main" repo:${owner}/${repo} in:body #${pr.number}`,
+              advanced_search: true
             });
             if (searchResults.data.items.length === 0) {
               core.info(`No 'internal/main' issue found for PR #${pr.number}. Exiting.`);


### PR DESCRIPTION
## Related Issue

Addresses #5  (main issue)

## Releases
none

## Description

This uses the issue search API directly, passing in the advanced search argument.

## Testing

actionlint
