### PR TITLE
fix: add team members individually to issue

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -33,7 +33,7 @@ jobs:
             const { data: associatedPrs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner,
               repo,
-              commit_sha: mergeCommitSha,
+              commit_sha: mergeCommitSha
             });
             const pr = associatedPrs.find(p => p.base.ref === 'main' && p.merged_at);
             if (!pr) {
@@ -46,10 +46,12 @@ jobs:
             core.info(`Searching for 'internal/main' issue linked to PR #${pr.number}`);
             const { data: searchResults } = await github.request('GET /search/issues', {
               q: `is:issue label:"internal/main" repo:${owner}/${repo} in:body #${pr.number}`,
+              advanced_search: true,
               headers: {
                 'X-GitHub-Api-Version': '2022-11-28'
               }
             });
+            core.info(`Search results: ${searchResults}`)
             if (searchResults.data.total_count === 0) {
               core.info(`No 'internal/main' issue found for PR #${pr.number}. Exiting.`);
               return;

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,14 +19,21 @@ jobs:
             const repo = context.repo.repo;
             const owner = context.repo.owner;
 
+            // Get terraform-maintainers team
+            const { data: teamMembers } = await github.rest.teams.listMembersInOrg({
+              org: "rancher",
+              team_slug: "terraform-maintainers"
+            });
+            const newAssignees = teamMembers.map(member => member.login);
+
             // Create the sub-issue
             const newIssue = await github.rest.issues.create({
               owner: owner,
               repo: repo,
               title: "Backport #" + parentIssueNumber + " to release/v0",
-              body:  "Backport #" + parentIssueNumber + " to release/v0"
-              labels: ['release/v0']
-              assignees: ['terraform-maintainers']
+              body:  "Backport #" + parentIssueNumber + " to release/v0",
+              labels: ['release/v0'],
+              assignees: newAssignees // assign terraform-maintainers to sub-issue
             });
 
             const subIssueId = newIssue.data.id;

--- a/.github/workflows/main-issue.yml
+++ b/.github/workflows/main-issue.yml
@@ -18,13 +18,22 @@ jobs:
             const repo = context.repo.repo;
             const owner = context.repo.owner;
             const pr = context.payload.pull_request;
-            const newLabels = ['internal/main']
+            const newLabels = ['internal/main'];
             const releaseLabel = pr.labels.find(label => label.name.startsWith('release/v'));
             if (releaseLabel) {
               const versionLabel = releaseLabel.name.replace('release/', 'version/');
-              newLabels.push(versionLabel)
+              newLabels.push(versionLabel);
             }
+            // Get terraform-maintainers team
+            const { data: teamMembers } = await github.rest.teams.listMembersInOrg({
+              org: "rancher",
+              team_slug: "terraform-maintainers"
+            });
+            const newAssignees = teamMembers.map(member => member.login);
+
             // Create the main issue
+            // https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue
+            // Note: issues can't have teams assigned to them
             const newIssue = await github.rest.issues.create({
               owner: owner,
               repo: repo,
@@ -34,5 +43,5 @@ jobs:
                 "Please add comments for user issues which this issue addresses. \n\n" +
                 "Description copied from PR: \n" + pr.body,
               labels: newLabels,
-              assignees: ['terraform-maintainers']
+              assignees: newAssignees // assign terraform-maintainers to issue
             });


### PR DESCRIPTION
## Related Issue

Addresses #5  (main issue)

## Releases

none

## Description

Teams can't be assigned to issues, so this gets each member of the team and assigns them to the issues.
This also adds a console line to see what is going on with the issue search results.

## Testing

actionlint
