### PR TITLE
fix: resolve merge conflicts in backport

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -89,7 +89,7 @@ jobs:
               execSync(`git config user.email "github-actions[bot]@users.noreply.github.com"`);
               execSync(`git fetch origin ${targetBranch}`);
               execSync(`git checkout -b ${newBranchName} origin/${targetBranch}`);
-              execSync(`git cherry-pick -x ${mergeCommitSha}`);
+              execSync(`git cherry-pick -x ${mergeCommitSha} -X theirs`);
               execSync(`git push origin ${newBranchName}`);
 
               core.info(`Creating pull request for branch ${newBranchName} targeting ${targetBranch}...`);
@@ -99,7 +99,9 @@ jobs:
                 title: pr.title,
                 head: newBranchName,
                 base: targetBranch,
-                body: "This pull request cherry-picks the changes from #" + pr.number + " into " + targetBranch,
+                body: "This pull request cherry-picks the changes from #" + pr.number + " into " + targetBranch + "\n" +
+                  "WARNING!: to avoid having to resolve merge conflicts this PR is generated with `git cherry-pick -X theirs`.\n" +
+                  "Please make sure to carefully inspect this PR so that you don't revert anything!",
                 assignees: ['terraform-maintainers']
               });
             }


### PR DESCRIPTION
## Related Issue

Addresses #5  (main issue)

## Releases

none

## Description

This will automatically resolve conflicts in backport PRs using the `-X theirs` strategy.
It adds risk to backport PRs, but allows the PRs to be created without fail.
In most cases this will be ok, but in the few instances where backports have merge conflicts we will ata least be able to see the problems in the review. 

We will need to be extra careful to make sure that backports don't remove important lines of code.

## Testing

actionlint
