### PR TITLE
fix: backport PR need individual assignees

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -29,6 +29,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const mergeCommitSha = context.payload.head_commit.id;
+            const assignees = ['matttrach', 'jiaqiluo', 'HarrisonWAffel'];
 
             const { data: associatedPrs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner,
@@ -100,9 +101,9 @@ jobs:
                 head: newBranchName,
                 base: targetBranch,
                 body: "This pull request cherry-picks the changes from #" + pr.number + " into " + targetBranch + "\n" +
-                  "Addresses #" + subIssueNumber + "for #" + mainIssue.number + " \n\n" +
+                  "Addresses #" + subIssueNumber + " for #" + mainIssue.number + " \n\n" +
                   "**WARNING!**: to avoid having to resolve merge conflicts this PR is generated with `git cherry-pick -X theirs`.\n" +
                   "Please make sure to carefully inspect this PR so that you don't accidentally revert anything!",
-                assignees: ['terraform-maintainers']
+                assignees: assignees
               });
             }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -42,7 +42,7 @@ jobs:
             const repo = context.repo.repo;
             const owner = context.repo.owner;
             const parentIssueBody = parentIssue.body;
-            const assignees = ['matttrach', 'jiaqiluo', 'HarrisonWAffel']
+            const assignees = ['matttrach', 'jiaqiluo', 'HarrisonWAffel'];
 
             const prNumber = ${{ steps.extract_pr.outputs.result }};
 

--- a/.github/workflows/main-issue.yml
+++ b/.github/workflows/main-issue.yml
@@ -23,7 +23,7 @@ jobs:
             if (releaseLabel) {
               newLabels.push(releaseLabel);
             }
-            const assignees = ['matttrach', 'jiaqiluo', 'HarrisonWAffel']
+            const assignees = ['matttrach', 'jiaqiluo', 'HarrisonWAffel'];
 
             // Note: can't get terraform-maintainers team, the default token can't access org level objects
             // Create the main issue


### PR DESCRIPTION
## Related Issue

Addresses #5 

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

Assigns backport PRs to individuals rather than the team, I think maybe even PRs can't be assigned to a team only the reviewers can be a team.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
