### PR TITLE
fix: add a new workflow for release candidates

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,70 @@
+name: release-candidate
+
+on:
+  push:
+    branches:
+    - release/v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0 https://github.com/googleapis/release-please-action/commits/main/
+        name: release-please
+        id: release-please
+        with:
+          skip-github-pull-request: true
+          config-file: release-please-config-rc.json
+          manifest-file: .release-please-manifest.json
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout
+        if: steps.release-please.outputs.version
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0 https://github.com/actions/setup-go
+        if: steps.release-please.outputs.version
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: retrieve GPG Credentials
+        if: steps.release-please.outputs.version
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
+            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
+            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
+      - name: import_gpg_key
+        if: steps.release-please.outputs.version
+        env:
+          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
+          GPG_KEY: ${{ env.GPG_KEY }}
+        run: |
+          cleanup() {
+            # clear history just in case
+            history -c
+          }
+          trap cleanup EXIT TERM
+
+          # sanitize variables
+          if [ -z "${GPG_PASSPHRASE}" ]; then echo "gpg passphrase empty"; exit 1; fi
+          if [ -z "${GPG_KEY_ID}" ]; then echo "key id empty"; exit 1; fi
+          if [ -z "${GPG_KEY}" ]; then echo "key contents empty"; exit 1; fi
+
+          echo "Importing gpg key"
+          echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
+      - name: Run GoReleaser
+        if: steps.release-please.outputs.version
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
       issues: write
       pull-requests: write
       actions: read
-    outputs:
-      release_pr: ${{ steps.release-please.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0 https://github.com/googleapis/release-please-action/commits/main/
         name: release-please
@@ -24,6 +22,7 @@ jobs:
           target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
       # These run only if a release PR was opened or modified, so not when the PR is merged
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1 https://github.com/actions/github-script/commits/main
         name: wait-for-e2e
@@ -86,43 +85,6 @@ jobs:
               repo: "${{ github.event.repository.name }}",
               body: "Tests Failed!"
             })
-      - name: retrieve GPG Credentials
-        if: steps.release-please.outputs.pr && (steps.run-unit-tests.conclusion == 'success')
-        uses: rancher-eio/read-vault-secrets@main
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
-            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
-            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
-      - name: import_gpg_key
-        if: steps.release-please.outputs.pr && (steps.run-unit-tests.conclusion == 'success')
-        env:
-          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
-          GPG_KEY: ${{ env.GPG_KEY }}
-        run: |
-          cleanup() {
-            # clear history just in case
-            history -c
-          }
-          trap cleanup EXIT TERM
-
-          # sanitize variables
-          if [ -z "${GPG_PASSPHRASE}" ]; then echo "gpg passphrase empty"; exit 1; fi
-          if [ -z "${GPG_KEY_ID}" ]; then echo "key id empty"; exit 1; fi
-          if [ -z "${GPG_KEY}" ]; then echo "key contents empty"; exit 1; fi
-
-          echo "Importing gpg key"
-          echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
-      - name: Run GoReleaser
-        if: steps.release-please.outputs.pr && (steps.run-unit-tests.conclusion == 'success')
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
-        with:
-          args: release --snapshot --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
-          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
 
       # These run after release-please generates a release, so when the release PR is merged
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,10 +50,6 @@ signs:
       - "${signature}"
       - "--sign"
       - "${artifact}"
-snapshot:
-  # "snapshot" is the type of release we use for release candidates
-  #  that are generated when a release branch gets a new merge
-  name_template: "{{ .ProjectName }}_{{ .ShortCommit }}"
 release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'

--- a/release-please-config-rc.json
+++ b/release-please-config-rc.json
@@ -6,7 +6,8 @@
       "include-v-in-tag": true,
       "include-component-in-tag": false,
       "always-update": true,
-      "initial-version": "v0.1.0"
+      "skip-changelog": true,
+      "versioning": "prerelease"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Related Issue

<!--- Add release labels (eg. release/v0) for each target release --->
Addresses #5

## Description

<!--- Describe your change and how it addresses the issue linked above. --->
Automatically generate release candidates every time there is a merge to a release branch.

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
