### PR TITLE
fix: tell release please not to skip the release

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -20,6 +20,7 @@ jobs:
         id: release-please
         with:
           skip-github-pull-request: true
+          skip-github-release: false
           config-file: release-please-config-rc.json
           manifest-file: .release-please-manifest.json
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout


### PR DESCRIPTION
## Related Issue

Addresses #5

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

Release please is skipping the PR as requested, but it is also skipping the release. Explicitly setting the skip release input to false in order to hopefully get a release candidate.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
