### PR TITLE
fix: add checkout action before release please

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -15,6 +15,9 @@ jobs:
       pull-requests: write
       actions: read
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout
+        with:
+          fetch-depth: 0
       - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0 https://github.com/googleapis/release-please-action/commits/main/
         name: release-please
         id: release-please

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
       pull-requests: write
       actions: read
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout
+        with:
+          fetch-depth: 0
       - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0 https://github.com/googleapis/release-please-action/commits/main/
         name: release-please
         id: release-please


### PR DESCRIPTION
## Related Issue

Addresses #5

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

Release please can't read the configuration files because the code isn't checked out when it is called.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
