### PR TITLE
fix: get version properly (#109)

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -99,10 +99,21 @@ jobs:
                 title: pr.title,
                 head: newBranchName,
                 base: targetBranch,
-                body: "This pull request cherry-picks the changes from #" + pr.number + " into " + targetBranch + "\n" +
-                  "Addresses #" + subIssueNumber + " for #" + mainIssue.number + " \n\n" +
-                  "**WARNING!**: to avoid having to resolve merge conflicts this PR is generated with `git cherry-pick -X theirs`.\n" +
-                  "Please make sure to carefully inspect this PR so that you don't accidentally revert anything!",
+                body: [
+                  `This pull request cherry-picks the changes from #${pr.number} into ${targetBranch}`,
+                  `Addresses #${subIssueNumber} for #${mainIssue.number}`,
+                  `**WARNING!**: to avoid having to resolve merge conflicts this PR is generated with 'git cherry-pick -X theirs'.`,
+                  `Please make sure to carefully inspect this PR so that you don't accidentally revert anything!`,
+                  `Please add the proper milestone to this PR`,
+                  `Copied from main PR:`,
+                  `${pr.body}`
+                ].join("\n\n")
+              });
+              const prNumber = newPR.number
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: prNumber,
                 assignees: assignees
               });
             }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -44,7 +44,12 @@ jobs:
             const parentIssueBody = parentIssue.body;
             const assignees = ['matttrach', 'jiaqiluo', 'HarrisonWAffel'];
 
-            const prNumber = ${{ steps.extract_pr.outputs.result }};
+            const { data: pr } = await github.rest.issues.get({
+              owner: owner,
+              repo: repo,
+              issue_number: ${{ steps.extract_pr.outputs.result }}
+            });
+            const prNumber = pr.number;
 
             // Note: can't get terraform-maintainers team, the default token can't access org level objects
             // Create the sub-issue
@@ -52,7 +57,11 @@ jobs:
               owner: owner,
               repo: repo,
               title: `Backport #${prNumber} to ${labelName}`,
-              body:  `Backport #${prNumber} to ${labelName} for #${parentIssueNumber}`,
+              body:  [
+                `Backport #${prNumber} to ${labelName} for #${parentIssueNumber}`,
+                `Copied from PR:`,
+                `${pr.body}`
+              ].join("\n\n")
               labels: [labelName],
               assignees: assignees
             });

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -18,15 +18,17 @@ jobs:
       - name: Create and Push RC Tag with Git
         run: |
           BASE_VERSION=$(echo "$GITHUB_REF" | sed 's/refs\/heads\/release\///')
-          echo "Base version is: $BASE_VERSION"
+          echo "Base version is: $BASE_VERSION" # gets v0 from release/v0 in branch name
           git fetch --tags
-          LATEST_RC_NUM=$(git tag | grep "^${BASE_VERSION}-rc." | sed 's/.*-rc.//' | sort -n | tail -1)
+          LATEST_MINOR_NUM=$(git tag | grep "^${BASE_VERSION}\." | awk -F. '{print $2}' | sort -n | tail -1)
+          LATEST_PATCH_NUM=$(git tag | grep "^${BASE_VERSION}\.${LATEST_MINOR_NUM}\." | awk -F. '{print $3}' | sort -n | tail -1)
+          LATEST_RC_NUM=$(git tag | grep "^${BASE_VERSION}\.${LATEST_MINOR_NUM}\.${LATEST_PATCH_NUM}-rc\." | sed 's/.*-rc.//' | sort -n | tail -1)
           if [ -z "$LATEST_RC_NUM" ]; then
             NEXT_RC_NUM=0
           else
             NEXT_RC_NUM=$((LATEST_RC_NUM + 1))
           fi
-          NEXT_RC_TAG="${BASE_VERSION}-rc.${NEXT_RC_NUM}"
+          NEXT_RC_TAG="${BASE_VERSION}.${LATEST_MINOR_NUM}.${LATEST_PATCH_NUM}-rc.${NEXT_RC_NUM}"
           echo "Calculated next RC tag: $NEXT_RC_TAG"
 
           # Configure git user


### PR DESCRIPTION
Backport #109 to release/v0
Addresses #111 for #110 

Copied from main PR:
## Related Issue

Addresses #5 

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

The release candidate automation is missing the minor and patch version numbers when looking for the latest rc version. This finds all parts of the version when generating the rc tag.
This also adds the main PR body to the backport PRs and issues and assigns the correct people to those backports.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
