### PR TITLE
fix: typo in backport pr script

### DIFF
--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -110,7 +110,7 @@ jobs:
                   `${pr.body}`
                 ].join("\n\n")
               });
-              const prNumber = newPR.number
+              const prNumber = newPr.number
               await github.rest.issues.addAssignees({
                 owner,
                 repo,


### PR DESCRIPTION
## Related Issue

Addresses #5 

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

Typo was preventing assignees on the backport PRs.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
