### PR TITLE
fix: correct the rc calculation

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -21,9 +21,16 @@ jobs:
           echo "Base version is: $BASE_VERSION" # gets v0 from release/v0 in branch name
           git fetch --tags
           LATEST_MINOR_NUM=$(git tag | grep "^${BASE_VERSION}\." | awk -F. '{print $2}' | sort -n | tail -1)
-          LATEST_PATCH_NUM=$(git tag | grep "^${BASE_VERSION}\.${LATEST_MINOR_NUM}\." | awk -F. '{print $3}' | sort -n | tail -1)
-          LATEST_RC_NUM=$(git tag | grep "^${BASE_VERSION}\.${LATEST_MINOR_NUM}\.${LATEST_PATCH_NUM}-rc\." | sed 's/.*-rc.//' | sort -n | tail -1)
+          echo "Latest minor num: $LATEST_MINOR_NUM"
+          LATEST_PATCH_NUM=$(git tag | grep "^${BASE_VERSION}\.${LATEST_MINOR_NUM}\." | awk -F- '{print $1}' | awk -F. '{print $3}' | sort -n | tail -1)
+          echo "Latest patch num: $LATEST_PATCH_NUM"
+          LATEST_RC_NUM=$(git tag | grep "^${BASE_VERSION}\.${LATEST_MINOR_NUM}\.${LATEST_PATCH_NUM}-rc\." | awk -F. '{print $4}' | grep -v '^$' | sort -n | tail -1)
+          echo "Latest rc num: $LATEST_RC_NUM"
           if [ -z "$LATEST_RC_NUM" ]; then
+            # the last minor was a full release, we need to start the next minor release candidate
+            # this sort of assumes there wont be a patch release
+            LATEST_MINOR_NUM=$((LATEST_MINOR_NUM + 1))
+            LATEST_PATCH_NUM=0
             NEXT_RC_NUM=0
           else
             NEXT_RC_NUM=$((LATEST_RC_NUM + 1))


### PR DESCRIPTION
## Related Issue

Addresses #5 

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

The rc version is getting a repeating "-rc-rc-rc" with every release. It is also calculating the rc based on the last release rather than the next one. This is due to the way we isolate the patch version in the script. Now we increment the minor if there isn't already an rc in place. In practice we should probably just manually tag the first rc of the expected next version just to get the ball rolling. 
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
