### PR TITLE
fix: hard code the owner and repo name

### DIFF
--- a/.github/workflows/backport-pr-manual.yml
+++ b/.github/workflows/backport-pr-manual.yml
@@ -1,4 +1,4 @@
-name: 'Auto Cherry-Pick to Release Branches'
+name: 'Manually Cherry-Pick to Release Branches'
 
 on:
   workflow_dispatch:
@@ -29,8 +29,8 @@ jobs:
         with:
           script: |
             const execSync = require('child_process').execSync;
-            const owner = github.repository_owner;
-            const repo = github.repository;
+            const owner = "rancher";
+            const repo = "terraform-provider-file";
             const mergeCommitSha = process.env.MERGE_COMMIT_SHA;
             const assignees = ['matttrach', 'jiaqiluo', 'HarrisonWAffel'];
 


### PR DESCRIPTION
## Related Issue

Addresses #5 

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

Manual workflow was having issues getting the repo and owner, there is no reason not to hard code them.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
