### PR TITLE
feat: make file and snapshot contents sensitive

### DIFF
--- a/docs/data-sources/local.md
+++ b/docs/data-sources/local.md
@@ -33,6 +33,6 @@ data "file_local" "basic_example" {
 
 ### Read-Only
 
-- `contents` (String) The file contents.
+- `contents` (String, Sensitive) The file contents.
 - `id` (String) Identifier derived from sha256+HMAC hash of file contents.
 - `permissions` (String) The file permissions.

--- a/docs/data-sources/snapshot.md
+++ b/docs/data-sources/snapshot.md
@@ -19,7 +19,7 @@ This data source retrieves the contents of a file from the output of a file_snap
 
 ### Required
 
-- `contents` (String) The contents of the snapshot to retrieve. This could be any gzip compressed base64 encoded data. If the data isn't compressed, set the decompress argument to false, or leave it blank. If the decompress argument is false, the data will be the base64 decoded contents.
+- `contents` (String, Sensitive) The contents of the snapshot to retrieve. This could be any gzip compressed base64 encoded data. If the data isn't compressed, set the decompress argument to false, or leave it blank. If the decompress argument is false, the data will be the base64 decoded contents.
 
 ### Optional
 
@@ -27,5 +27,5 @@ This data source retrieves the contents of a file from the output of a file_snap
 
 ### Read-Only
 
-- `data` (String) The resulting data output. This is the plain text representation of the contents attribute. This is computed by first decoding the data from base64, then decompressing the resulting gzip. If decompress is false, then this will be the base64 decoded version of the contents.
+- `data` (String, Sensitive) The resulting data output. This is the plain text representation of the contents attribute. This is computed by first decoding the data from base64, then decompressing the resulting gzip. If decompress is false, then this will be the base64 decoded version of the contents.
 - `id` (String) Unique identifier for the datasource. The SHA256 hash of the contents.

--- a/docs/resources/local.md
+++ b/docs/resources/local.md
@@ -39,7 +39,7 @@ resource "file_local" "protected_example" {
 
 ### Required
 
-- `contents` (String) File contents, required.
+- `contents` (String, Sensitive) File contents, required.
 - `name` (String) File name, required.
 
 ### Optional

--- a/docs/resources/snapshot.md
+++ b/docs/resources/snapshot.md
@@ -70,7 +70,8 @@ data "file_local" "snapshot_file_example_after_update" {
 }
 
 output "file" {
-  value = data.file_local.snapshot_file_example_after_update.contents
+  value     = data.file_local.snapshot_file_example_after_update.contents
+  sensitive = true
   # this updates a file that is used to show how snapshots work
 }
 output "snapshot" {

--- a/examples/resources/file_snapshot/resource.tf
+++ b/examples/resources/file_snapshot/resource.tf
@@ -54,7 +54,8 @@ data "file_local" "snapshot_file_example_after_update" {
 }
 
 output "file" {
-  value = data.file_local.snapshot_file_example_after_update.contents
+  value     = data.file_local.snapshot_file_example_after_update.contents
+  sensitive = true
   # this updates a file that is used to show how snapshots work
 }
 output "snapshot" {

--- a/internal/provider/file_local/file_local_data_source.go
+++ b/internal/provider/file_local/file_local_data_source.go
@@ -64,6 +64,7 @@ func (r *LocalDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 			"contents": schema.StringAttribute{
 				MarkdownDescription: "The file contents.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"permissions": schema.StringAttribute{
 				MarkdownDescription: "The file permissions.",

--- a/internal/provider/file_local/file_local_resource.go
+++ b/internal/provider/file_local/file_local_resource.go
@@ -70,6 +70,7 @@ func (r *LocalResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"contents": schema.StringAttribute{
 				MarkdownDescription: "File contents, required.",
 				Required:            true,
+				Sensitive:           true,
 			},
 			"directory": schema.StringAttribute{
 				MarkdownDescription: "The directory where the file will be placed, defaults to the current working directory.",

--- a/internal/provider/file_snapshot/snapshot_data_source.go
+++ b/internal/provider/file_snapshot/snapshot_data_source.go
@@ -50,7 +50,8 @@ func (r *SnapshotDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 					"This could be any gzip compressed base64 encoded data. " +
 					"If the data isn't compressed, set the decompress argument to false, or leave it blank. " +
 					"If the decompress argument is false, the data will be the base64 decoded contents.",
-				Required: true,
+				Required:  true,
+				Sensitive: true,
 			},
 			"decompress": schema.BoolAttribute{
 				MarkdownDescription: "Whether or not to decompress the contents. " +
@@ -66,7 +67,8 @@ func (r *SnapshotDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 				MarkdownDescription: "The resulting data output. This is the plain text representation of the contents attribute. " +
 					"This is computed by first decoding the data from base64, then decompressing the resulting gzip. " +
 					"If decompress is false, then this will be the base64 decoded version of the contents.",
-				Computed: true,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
## Related Issue

Addresses #144 

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

Makes sure file contents, snapshots, and snapshot contents all stay out of logs.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

Adjusted e2e tests to verify change.
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
