### PR TITLE
fix: goreleaser tag race condition

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
-          args: release --clean
+          args: release --clean --config .goreleaser_rc.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,9 +129,9 @@ jobs:
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: Run GoReleaser
         if: steps.release-please.outputs.version
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
-          args: release --clean
+          args: release --clean --config .goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}

--- a/.goreleaser_rc.yml
+++ b/.goreleaser_rc.yml
@@ -6,9 +6,6 @@ version: 2
 before:
   hooks:
     - go mod tidy
-git:
-  ignore_tags:
-    - "*rc*"
 builds:
   - binary: '{{ .ProjectName }}_v{{ .Version }}'
     env:


### PR DESCRIPTION
## Related Issue

Addresses #174 

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

Resolves a race condition with the release-candidate workflow and the release workflow.
Goreleaser looks at the latest tag to determine where to place build artifacts.
I created two Goreleaser configs, one for the rc and one for the main release.
The main release run of Goreleaser will now ignore .rc tags and update the last full release with build artifacts.
The rc release of Goreleaser will work as it has before, but not using a different Goreleaser config file.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
