### PR TITLE
fix: remove all to prevent missing file errors

### DIFF
--- a/internal/provider/file_client/file_os_client.go
+++ b/internal/provider/file_client/file_os_client.go
@@ -64,7 +64,7 @@ func (c *OsFileClient) Update(currentDirectory string, currentName string, newDi
 
 func (c *OsFileClient) Delete(directory string, name string) error {
 	path := filepath.Join(directory, name)
-	return os.Remove(path)
+	return os.RemoveAll(path)
 }
 
 func (c *OsFileClient) Compress(directory string, name string, outputName string) error {


### PR DESCRIPTION
## Related Issue

Addresses #

<!--- Add release labels (eg. release/v0) for each target release --->

## Description

This addresses a bug I have been seeing in the Rancher AWS module where removing the encoded file is throwing an error that the file doesn't exist. This shouldn't be an error, it is the desired behavior. This changes us to using the os.RemoveAll function vs the os.Remove function. The os.RemoveAll function returns nil if the file doesn't exist, this should clear up any remove errors.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
