### PR TITLE
fix: restrict goreleaser generating rc releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG]'
+labels: 
+- 'kind/bug'
+- 'internal/user'
+assignees:
+- 'matttrach'
+- 'jiaqiluo'
+- 'HarrisonWAffel'
+
+---
+
+### Environment Information
+<!--Please add information on the same line in quotes. Eg. - Terraform version: "v1.11.0" -->
+- Terraform version:
+- Provider version:
+
+### Describe the bug
+
+### To Reproduce
+
+### Actual Result
+
+### Expected Result

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[RFE] '
+labels: 
+- 'kind/enhancement'
+- 'internal/user'
+assignees: 'matttrach'
+
+---
+
+### Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
-## Related Issue
-
+<!--- If there is no user issue related to this then you should remove the next line --->
 Addresses #
 
-<!--- Add release labels (eg. release/v0) for each target release --->
+<!--- Add release labels (eg. release/v2) for each target release --->
+<!--- Labels need to be added before PR is created for automation to run smoothly! --->
 
 ## Description
 
@@ -12,5 +12,6 @@ Addresses #
 
 <!--- Please describe how you verified this change or why testing isn't relevant. --->
 
-<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
+<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
+<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
 Not a breaking change.

--- a/.github/workflows/backport-issues.yml
+++ b/.github/workflows/backport-issues.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   create-issue:
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.event.label.name, 'release/v') }}
+    if: ${{ startsWith(github.event.label.name, 'release/v') }} # only works for release labels
     steps:
       - name: Find and Verify PR Number
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script

--- a/.github/workflows/backport-pr-manual.yml
+++ b/.github/workflows/backport-pr-manual.yml
@@ -93,7 +93,7 @@ jobs:
               execSync(`git config user.email "github-actions[bot]@users.noreply.github.com"`);
               execSync(`git fetch origin ${targetBranch}`);
               execSync(`git checkout -b ${newBranchName} origin/${targetBranch}`);
-              execSync(`git cherry-pick -x ${mergeCommitSha} -X theirs`);
+              execSync(`git cherry-pick --allow-empty -x ${mergeCommitSha} -X theirs`);
               execSync(`git push origin ${newBranchName}`);
 
               core.info(`Creating pull request for branch ${newBranchName} targeting ${targetBranch}...`);

--- a/.github/workflows/backport-prs.yml
+++ b/.github/workflows/backport-prs.yml
@@ -90,7 +90,7 @@ jobs:
               execSync(`git config user.email "github-actions[bot]@users.noreply.github.com"`);
               execSync(`git fetch origin ${targetBranch}`);
               execSync(`git checkout -b ${newBranchName} origin/${targetBranch}`);
-              execSync(`git cherry-pick -x ${mergeCommitSha} -X theirs`);
+              execSync(`git cherry-pick --allow-empty -x ${mergeCommitSha} -X theirs`);
               execSync(`git push origin ${newBranchName}`);
 
               core.info(`Creating pull request for branch ${newBranchName} targeting ${targetBranch}...`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
       # If the e2e tests pass we automatically generate an RC release
       #   this shouldn't happen when the release PR is merged, only when it's opened or updated
       - name: Create and Push RC Tag with Git
+        id: create-push-rc-tag
         if: steps.release-please.outputs.pr && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success')
         run: |
           BASE_VERSION=$(echo "$GITHUB_REF" | sed 's/refs\/heads\/release\///')
@@ -123,6 +124,8 @@ jobs:
           git tag "$NEXT_RC_TAG" -m "Release Candidate $NEXT_RC_TAG"
           git push origin "$NEXT_RC_TAG"
       - name: retrieve GPG Credentials
+        id: retrieve-gpg-credentials
+        if: steps.release-please.outputs.pr && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success') && (steps.create-push-rc-tag.conclusion == 'success')
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
@@ -130,6 +133,8 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
       - name: import_gpg_key
+        id: import-gpg-key
+        if: steps.release-please.outputs.pr && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success') && (steps.create-push-rc-tag.conclusion == 'success') && (steps.retrieve-gpg-credentials.conclusion == 'success')
         env:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
@@ -149,6 +154,7 @@ jobs:
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: Run GoReleaser
+        if: steps.release-please.outputs.pr && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success') && (steps.create-push-rc-tag.conclusion == 'success') && (steps.retrieve-gpg-credentials.conclusion == 'success') && (steps.import-gpg-key.conclusion == 'success')
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
           args: release --clean --config .goreleaser_rc.yml

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description

Go releaser is triggering an rc release when it should be doing a full release.
Backport cherry-pick automation should allow empty commits so that users can request a release.
We need to update issue templates.
<!--- Describe your change and how it addresses the issue linked above. --->

## Testing

Actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
