### PR TITLE
fix: work around draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,61 @@ env:
   NIX_INSTALL_VERSION: 2.34.7
 
 jobs:
-  release:
+  release-please-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
-      issues: write
       pull-requests: write
-      actions: read
+    outputs:
+      version: ${{ steps.release-please-release.outputs.version }}
+      release_created: ${{ steps.release-please-release.outputs.release_created }}
+    steps:
+      - name: Release Please (Release Only)
+        # https://github.com/googleapis/release-please-action/releases
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release-please-release
+        with:
+          target-branch: ${{ github.ref_name }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
+
+  release-please-pr:
+    needs:
+      - release-please-release
+      - release
+    if: |
+      !cancelled() &&
+      needs.release-please-release.result == 'success' &&
+      (needs.release.result == 'success' || needs.release.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      prs_created: ${{ steps.release-please-pr.outputs.prs_created }}
+      pr: ${{ steps.release-please-pr.outputs.pr }}
+    steps:
+      - name: Release Please (PR Only)
+        # https://github.com/googleapis/release-please-action/releases
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release-please-pr
+        with:
+          target-branch: ${{ github.ref_name }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
+
+  # Release tests only run if release-please created or updated a PR
+  release-test:
+    needs: release-please-pr
+    if: needs.release-please-pr.outputs.prs_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      outcome: ${{ steps.run-unit-tests.conclusion == 'success' && steps.run-acc-tests.conclusion == 'success' }}
     steps:
       - name: install-nix
         run: |
@@ -29,86 +76,81 @@ jobs:
           nix --version
           which nix
           rm -f ./install-nix.sh
-        # https://github.com/actions/checkout/releases
+      # https://github.com/actions/checkout/releases
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-        # https://github.com/googleapis/release-please-action/releases
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
-        name: release-please
-        id: release-please
-        with:
-          target-branch: ${{ github.ref_name }}
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-
-        # These run only if a release PR was opened or modified, so not when the PR is merged
-        # https://github.com/actions/github-script/releases
+      # https://github.com/actions/github-script/releases
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         name: wait-for-e2e
-        if: steps.release-please.outputs.prs_created
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
-              issue_number: ${{ fromJson(steps.release-please.outputs.pr).number }},
+              issue_number: ${{ fromJson(needs.release-please-pr.outputs.pr).number }},
               owner: "${{ github.repository_owner }}",
               repo: "${{ github.event.repository.name }}",
               body: "Please make sure e2e tests pass before merging this PR! \n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             })
-        # https://github.com/actions/checkout/releases
+      # https://github.com/actions/checkout/releases
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: steps.release-please.outputs.prs_created
-        # https://github.com/actions/setup-go/releases
+      # https://github.com/actions/setup-go/releases
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        if: steps.release-please.outputs.prs_created
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: run-unit-tests
         id: run-unit-tests
-        if: steps.release-please.outputs.prs_created
         run: |
           # https://github.com/gotestyourself/gotestsum/releases
           go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f # v1.13.0
           make test
       - name: run-acc-tests
         id: run-acc-tests
-        if: steps.release-please.outputs.prs_created
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: make testacc
+      - name: report-tests-passed
         # https://github.com/actions/github-script/releases
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        name: report-tests-passed
-        if: steps.release-please.outputs.prs_created && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success')
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
-              issue_number: ${{ fromJson(steps.release-please.outputs.pr).number }},
+              issue_number: ${{ fromJson(needs.release-please-pr.outputs.pr).number }},
               owner: "${{ github.repository_owner }}",
               repo: "${{ github.event.repository.name }}",
               body: "Tests Passed!"
             })
-        # https://github.com/actions/github-script/releases
+      # https://github.com/actions/github-script/releases
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         name: report-tests-failed
-        if: steps.release-please.outputs.prs_created && always() && ((steps.run-unit-tests.conclusion == 'failure') || (steps.run-acc-tests.conclusion == 'failure'))
+        if: always() && ((steps.run-unit-tests.conclusion == 'failure') || (steps.run-acc-tests.conclusion == 'failure'))
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
-              issue_number: ${{ fromJson(steps.release-please.outputs.pr).number }},
+              issue_number: ${{ fromJson(needs.release-please-pr.outputs.pr).number }},
               owner: "${{ github.repository_owner }}",
               repo: "${{ github.event.repository.name }}",
               body: "Tests Failed!"
             })
 
+  # This runs if release-please created or updated a PR, tests run and pass
+  rc-release:
+    needs:
+      - release-please-pr
+      - release-test
+    if: needs.release-please-pr.outputs.prs_created == 'true' && needs.release-test.outputs.outcome == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
       # If the e2e tests pass we automatically generate an RC release
       #   this shouldn't happen when the release PR is merged, only when it's opened or updated
       - name: Create and Push RC Tag with Git
         id: create-push-rc-tag
-        if: steps.release-please.outputs.prs_created && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success')
         run: |
           BASE_VERSION=$(echo "$GITHUB_REF" | sed 's/refs\/heads\/release\///')
           echo "Base version is: $BASE_VERSION" # gets v0 from release/v0 in branch name
@@ -148,7 +190,6 @@ jobs:
           echo "RC_BRANCH=release/$BASE_VERSION" >> "$GITHUB_ENV"
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
-        if: steps.release-please.outputs.prs_created && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success') && (steps.create-push-rc-tag.conclusion == 'success')
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
@@ -157,7 +198,6 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
       - name: import_gpg_key
         id: import-gpg-key
-        if: steps.release-please.outputs.prs_created && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success') && (steps.create-push-rc-tag.conclusion == 'success') && (steps.retrieve-gpg-credentials.conclusion == 'success')
         env:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
@@ -177,7 +217,6 @@ jobs:
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: Run GoReleaser
-        if: steps.release-please.outputs.prs_created && always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success') && (steps.create-push-rc-tag.conclusion == 'success') && (steps.retrieve-gpg-credentials.conclusion == 'success')
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -187,20 +226,26 @@ jobs:
           goreleaser release --clean --config .goreleaser_rc.yml
         # GoReleaser will automatically set RC releases to prerelease instead of draft (no need to publish)
 
-        # These run after release-please generates a release, so when the release PR is merged
+
+  # These run after release-please generates a release
+  release:
+    needs: release-please-release
+    if: needs.release-please-release.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
         # https://github.com/actions/checkout/releases
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: steps.release-please.outputs.release_created
         with:
           fetch-depth: 0
         # https://github.com/actions/setup-go/releases
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        if: steps.release-please.outputs.release_created
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: retrieve GPG Credentials
-        if: steps.release-please.outputs.release_created
           # https://github.com/rancher-eio/read-vault-secrets/commits
         uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
         with:
@@ -209,7 +254,6 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
       - name: import_gpg_key
-        if: steps.release-please.outputs.release_created
         env:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
@@ -229,7 +273,6 @@ jobs:
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: Run GoReleaser
-        if: steps.release-please.outputs.release_created
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -238,11 +281,10 @@ jobs:
         run: |-
           goreleaser release --clean --config .goreleaser.yml
       - name: Publish Release
-        if: steps.release-please.outputs.release_created
         # https://github.com/actions/github-script/releases
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          VERSION: ${{ steps.release-please.outputs.version }}
+          VERSION: ${{ needs.release-please-release.outputs.version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
This is an interesting problem. Release please fumbles a bit when it creates a draft release.
When creating a release it looks at the previous git tag and generates a new PR for any commits since the tag, knowing that the tag was just created when the release pr was merged. (so, it generates a tag then generates a release, then looks for new commits). When the release was a draft it can't find the tag and adds every commit ever to the new PR. 

To work around this problem we relegate release-please to either generating a PR or generating a release, and we run release-please twice, once at the beginning to generate a release (without a PR), then once after release to either generate a new PR from a merge commit or generate a new PR after the release.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
