### PR TITLE
fix: tag the draft release for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,23 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - name: Create and Push Tag
+        env:
+          VERSION: ${{ needs.release-please-release.outputs.version }}
+        run: |
+          TAG=$VERSION
+          if [[ $TAG != v* ]]; then
+            TAG="v$TAG"
+          fi
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          if ! git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
+            git tag "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+          else
+            echo "Tag $TAG already exists."
+          fi
         # https://github.com/actions/setup-go/releases
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Release please doesn't tag when generating a draft release.
We need to create the tag for it.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
