### PR TITLE
fix: use existing draft go release config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,7 @@ release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  prerelease: auto
+  draft: true
+  use_existing_draft: true
 changelog:
   disable: true


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Configure goreleaser to find the draft release that release-please creates and upload the artifacts to it. Then the last step will finalize the release by publishing it.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
