### PR TITLE
fix: remote workflow script pathing

### DIFF
--- a/.agent/agent-memory/FixWorkflowDynamicImports_temp.md
+++ b/.agent/agent-memory/FixWorkflowDynamicImports_temp.md
@@ -1,0 +1,34 @@
+# Temporary Plan: Fix Workflow Dynamic Imports
+
+**Executed Date:** 2026-07-23
+**Purpose:** Fix the `TypeError [ERR_INVALID_MODULE_SPECIFIER]` failure in GitHub Actions by refactoring dynamic imports in workflows to use absolute paths resolved via `process.env.GITHUB_WORKSPACE`.
+
+## Phase 1: Update Manual RC Release Workflow
+**Objective**: Fix dynamic imports in `.github/workflows/manual-rc-release.yml`.
+
+- [x] Update `check-maintainer` step (line 41): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `create-push-rc-tag` step (line 66): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `publish-rc` step (line 126): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+
+## Phase 2: Update Manual Release Workflow
+**Objective**: Fix dynamic imports in `.github/workflows/manual-release.yml`.
+
+- [x] Update `check-maintainer` step (line 35): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `create-push-tag` step (line 60): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `publish-release` step (line 120): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+
+## Phase 3: Update Main Release Workflow
+**Objective**: Fix dynamic imports in `.github/workflows/release.yml`.
+
+- [x] Update `post-pr-comment` step (line 99): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `post-pr-comment` step (line 132): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `post-pr-comment` step (line 148): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `create-push-rc-tag` step (line 185): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `create-push-tag` step (line 243): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+- [x] Update `publish-release` step (line 285): Use `process.env.GITHUB_WORKSPACE` to resolve absolute path.
+
+## Phase 4: Validation
+**Objective**: Validate yaml syntax and format of the updated workflows.
+
+- [x] Verify that all updated workflow files have valid YAML syntax.
+- [x] Run linting / validation check on modified files.

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const scriptPath = `.github/workflows/scripts/check-maintainer.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/check-maintainer.js`;
             const { default: script } = await import(scriptPath);
             return await script({github, context, core, process});
       - name: 'Validate RC Tag'
@@ -63,7 +63,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const scriptPath = `.github/workflows/scripts/create-push-tag.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});
       - name: 'Checkout New Tag'
@@ -123,6 +123,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const scriptPath = `.github/workflows/scripts/publish-release.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/publish-release.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const scriptPath = `.github/workflows/scripts/check-maintainer.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/check-maintainer.js`;
             const { default: script } = await import(scriptPath);
             return await script({github, context, core, process});
       - name: 'Validate Release Tag'
@@ -57,7 +57,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const scriptPath = `.github/workflows/scripts/create-push-tag.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});
       - name: 'Checkout New Tag'
@@ -117,6 +117,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const scriptPath = `.github/workflows/scripts/publish-release.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/publish-release.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const scriptPath = `.github/workflows/scripts/post-pr-comment.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/post-pr-comment.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});
       - name: Checkout Repository Again
@@ -129,7 +129,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const scriptPath = `.github/workflows/scripts/post-pr-comment.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/post-pr-comment.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});
       - name: Report Tests Failed
@@ -145,7 +145,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const scriptPath = `.github/workflows/scripts/post-pr-comment.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/post-pr-comment.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});
 
@@ -182,7 +182,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const scriptPath = `.github/workflows/scripts/create-push-tag.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});
       - name: Retrieve GPG Credentials
@@ -240,7 +240,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const scriptPath = `.github/workflows/scripts/create-push-tag.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});
       - name: Setup Go
@@ -282,6 +282,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const scriptPath = `.github/workflows/scripts/publish-release.js`;
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/publish-release.js`;
             const { default: script } = await import(scriptPath);
             await script({github, context, core, process});


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
### Cause of the Error
In Node.js ECMAScript Modules (ESM) environments, dynamic imports (import()) require a valid relative path specifier starting with ./ or
../, or an absolute path. Specifying .github/workflows/... directly causes Node.js to interpret it as a package name, throwing the
TypeError [ERR_INVALID_MODULE_SPECIFIER] error.

### Solution Applied
To fix this, I updated all 12 dynamic imports across the three affected workflow files to resolve their script paths using the absolute
process.env.GITHUB_WORKSPACE variable, matching the established pattern in other repositories:
 1. .github/workflows/manual-rc-release.yml (3 imports)
 2. .github/workflows/manual-release.yml (3 imports)
 3. .github/workflows/release.yml (6 imports)

All workflow changes were then run through actionlint and verified to be syntactically valid and compliant.

Additionally, I recorded our work progress in a temporary plan file located at:
.agent/agent-memory/FixWorkflowDynamicImports_temp.md

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
