### PR TITLE
fix: add temp nix script to gitignore for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,6 @@ bin/
 dist/
 modules-dev/
 /pkg/
-website/.vagrant
-website/.bundle
-website/build
-website/node_modules
 .vagrant/
 *.backup
 ./*.tfstate
@@ -27,11 +23,4 @@ website/node_modules
 *.iml
 report.json
 
-website/vendor
-
-# Test exclusions
-!command/test-fixtures/**/*.tfstate
-!command/test-fixtures/**/.terraform/
-
-# Keep windows files with windows line endings
-*.winfile eol=crlf
+.nix-script.sh


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Release CI is breaking because there is a temp script that the workflow uses to execute commands in the nix shell.
Example failing CI:
https://github.com/rancher/terraform-provider-file/actions/runs/29987772292/job/89143547814

GoReleaser expects a clean git status when building, this adds the temp script to the .gitignore so that the status will be clean.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
