### PR TITLE
fix: pass github token to releaser and fix release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      prs_created: ${{ steps.release-please-pr.outputs.prs_created }}
       pr: ${{ steps.release-please-pr.outputs.pr }}
       version: ${{ steps.release-please-pr.outputs.version || steps.release-please-pr.outputs['.--version'] }}
     steps:
@@ -66,7 +65,7 @@ jobs:
   # Release tests only run if release-please created or updated a PR
   release-test:
     needs: release-please-pr
-    if: needs.release-please-pr.outputs.prs_created == 'true'
+    if: needs.release-please-pr.outputs.pr != ''
     name: 'Release Tests'
     runs-on: ubuntu-latest
     container:
@@ -154,7 +153,7 @@ jobs:
     needs:
       - release-please-pr
       - release-test
-    if: needs.release-please-pr.outputs.prs_created == 'true' && needs.release-test.outputs.outcome == 'true'
+    if: needs.release-please-pr.outputs.pr != '' && needs.release-test.outputs.outcome == 'true'
     name: 'RC Release'
     runs-on: ubuntu-latest
     container:
@@ -262,6 +261,7 @@ jobs:
       - name: Run GoReleaser
         id: run-goreleaser
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_KEY: ${{ env.GPG_KEY }}


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
https://github.com/rancher/terraform-provider-file/actions/runs/30035193790/job/89301545357
Release CI is broken due to missing the github token. This adds the GitHub token to the environment variables.

This also fixes an error where release tests weren't triggering properly.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
