### PR TITLE
fix: update goreleaser config with some troubleshooting information

### DIFF
--- a/.github/workflows/scripts/goreleaser.sh
+++ b/.github/workflows/scripts/goreleaser.sh
@@ -15,15 +15,20 @@ if [[ -z "${GPG_KEY:-}" ]]; then echo "Error: GPG_KEY is empty" >&2; exit 1; fi
 echo "Importing GPG key..."
 echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Error: Failed to import GPG key" >&2; exit 1; }
 
-if [[ -n "${WORKING_DIR:-}" ]]; then
-  cd "${WORKING_DIR}"
+# https://www.gnupg.org/documentation/manuals/gnupg24/gpg.1.html
+# https://goreleaser.com/customization/sign/sign/
+# troubleshooting information
+gpg --version
+# this only lists UIDs no secret material
+gpg --batch --list-secret-keys --keyid-format LONG
+# this will fail if the secret key isn't present
+gpg --batch --list-secret-keys --keyid-format LONG "${GPG_KEY_ID}" >/dev/null
+# troubleshooting information
+goreleaser --version
+
+if [ -f .goreleaser.yml ]; then
+  goreleaser release --clean --config .goreleaser.yml
+else
+  echo "Error: .goreleaser.yml not found" >&2
+  exit 1
 fi
-
-ARGS=("--clean")
-if [[ "${SKIP_VALIDATE:-false}" == "true" ]]; then
-  ARGS+=("--skip=validate")
-fi
-
-ARGS+=("--config" "${GORELEASER_CONFIG:-.goreleaser.yml}")
-
-goreleaser release "${ARGS[@]}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,8 +44,9 @@ checksum:
   algorithm: sha256
 signs:
   - artifacts: checksum
+    cmd: gpg
     args:
-      - "--detach-sig"
+      - "--detach-sign"
       - "--pinentry-mode"
       - "loopback"
       - "--passphrase"

--- a/custom_words.txt
+++ b/custom_words.txt
@@ -1,6 +1,8 @@
 agentic
 authconfig
 containerize
+docker
+goreleaser
 kubeconfig
 nutanix
 pathing

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784555310,
-        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
+        "lastModified": 1785141334,
+        "narHash": "sha256-kh35kIx7el4Jk8Ki3BH9/Pn1eZYSYLJ6LMALos0zOy0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
+        "rev": "38a4887411571457d700c51c64a6e49ead2ed5ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
https://github.com/rancher/terraform-provider-file/actions/runs/30131281094
Release CI is failing, it says that there isn't a secret key, when the import says that it imported the secret key.

This adds some troubleshooting information as well as a change to the Goreleaser config to attempt to resolve.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
