### PR TITLE
fix: fix release please config and create local tag for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,18 +224,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Create and Push Tag
-        id: create-push-tag
-        # https://github.com/actions/github-script/releases
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Create Local Tag
+        id: create-local-tag
         env:
           VERSION: ${{ needs.release-please-release.outputs.version }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
-            const { default: script } = await import(scriptPath);
-            await script({github, context, core, process});
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-local-tag.sh
       - name: Setup Go
         id: setup-go
         # https://github.com/actions/setup-go/releases

--- a/.github/workflows/scripts/create-local-tag.sh
+++ b/.github/workflows/scripts/create-local-tag.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${VERSION:-}" ]]; then
+  echo "Error: VERSION environment variable is required." >&2
+  exit 1
+fi
+
+TAG="v${VERSION#v}"
+echo "Creating local tag: ${TAG}"
+
+# Check if tag already exists locally
+if git rev-parse "${TAG}" >/dev/null 2>&1; then
+  echo "Local tag ${TAG} already exists."
+else
+  git tag "${TAG}"
+fi

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,5 +6,10 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "always-update": true,
-  "initial-version": "v0.1.0"
+  "initial-version": "v0.1.0",
+  "packages": {
+    ".": {
+      "release-type": "go"
+    }
+  }
 }


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
1. Immutable Releases Issue: Pushing the release tag to remote before publishing the draft release triggered tag-locking under the Immutable Releases policy. We replaced this step with a local-tagging script (create-local-tag.sh), allowing GoReleaser to build locally and deferring the remote tag creation to GitHub's atomic draft-to-published transition during publishing (publish-release.js).

2. Release Please Config: Verified that the required packages attribute is fully configured in release-please-config.json to comply with the release-please v4+ schema.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
Both modifications have been successfully validated using actionlint and shellcheck with zero errors!


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
