### PR TITLE
fix: pass version to local tag script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
         id: create-local-tag
         env:
           VERSION: ${{ needs.release-please-release.outputs.version }}
-        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-local-tag.sh
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-local-tag.sh "${{ needs.release-please-release.outputs.version }}"
       - name: Setup Go
         id: setup-go
         # https://github.com/actions/setup-go/releases

--- a/.github/workflows/scripts/create-local-tag.sh
+++ b/.github/workflows/scripts/create-local-tag.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+VERSION="${1:-${VERSION:-}}"
+
 if [[ -z "${VERSION:-}" ]]; then
-  echo "Error: VERSION environment variable is required." >&2
+  echo "Error: VERSION argument or environment variable is required." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
https://github.com/rancher/terraform-provider-file/actions/runs/30474146173/job/90651732440
Release CI is failing because the local tag script using the nix script isn't translating the version env variable.
This passes the version as an argument to the script.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
