### PR TITLE
fix: fix release-please config putting draft in packages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
-  "prerelease": true,
+  "prerelease": false,
   "draft": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
@@ -9,7 +9,10 @@
   "initial-version": "v0.1.0",
   "packages": {
     ".": {
-      "release-type": "go"
+      "release-type": "go",
+      "draft": true,
+      "prerelease": false,
+      "include-v-in-tag": true
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
https://github.com/rancher/terraform-provider-file/actions/runs/30474146173/job/90651489438
Release is failing, it seems like release-please is creating full releases when it should be creating drafts.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
