### PR TITLE
fix: add checkout before release-please and add force-tag-creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
       version: ${{ steps.release-please-release.outputs.version }}
       release_created: ${{ steps.release-please-release.outputs.release_created }}
     steps:
+      - name: Checkout Repository
+        id: checkout-repository
+        # https://github.com/actions/checkout/releases
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
       - name: Release Please (Release Only)
         id: release-please-release
         # https://github.com/googleapis/release-please-action/releases
@@ -52,6 +59,12 @@ jobs:
       pr: ${{ steps.release-please-pr.outputs.pr || steps.release-please-pr.outputs['.--pr'] }}
       version: ${{ steps.release-please-pr.outputs.version || steps.release-please-pr.outputs['.--version'] }}
     steps:
+      - name: Checkout Repository
+        id: checkout-repository
+        # https://github.com/actions/checkout/releases
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Release Please (PR Only)
         id: release-please-pr
         # https://github.com/googleapis/release-please-action/releases

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "go",
   "prerelease": false,
   "draft": true,
+  "force-tag-creation": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "always-update": true,
@@ -12,6 +13,7 @@
       "release-type": "go",
       "draft": true,
       "prerelease": false,
+      "force-tag-creation": true,
       "include-v-in-tag": true
     }
   }


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Release CI is failing: https://github.com/rancher/terraform-provider-file/actions/runs/30480739642/job/90674246152

The 'force-tag-creation' config was missing.
Added a checkout step before running release-please so that the config will be in place.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
