### PR TITLE
fix: release please no longer creates releases

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,8 +16,32 @@ env:
 permissions: {}
 
 jobs:
+  enforce-fork-contribution:
+    name: 'Enforce Fork Contributions'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Contribution Origin
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          # Block anyone other than github-actions[bot] from using the release-please branch name
+          if [[ "$HEAD_REF" == "release-please--branches--main" && "$ACTOR" != "github-actions[bot]" ]]; then
+            echo "Error: Spoofing release-please branch is blocked. Only the system bot is allowed to use this branch." >&2
+            exit 1
+          fi
+
+          # Block direct pushes to main from same-repository (except for release-please PR)
+          if [[ "$HEAD_REPO" == "$BASE_REPO" && "$HEAD_REF" != "release-please--branches--main" ]]; then
+            echo "Error: Contributions are required to come from forks. Directly pushing branches to the upstream repository is blocked." >&2
+            exit 1
+          fi
+
   terraform:
     name: 'Terraform'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -37,6 +61,7 @@ jobs:
 
   actionlint:
     name: 'Lint Workflows'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -56,6 +81,7 @@ jobs:
 
   shellcheck:
     name: 'Shellcheck'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -75,6 +101,7 @@ jobs:
 
   validate-commit-message:
     name: 'Validate Commit Message'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -95,6 +122,7 @@ jobs:
 
   gitleaks:
     name: 'Scan for Secrets'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -115,6 +143,7 @@ jobs:
 
   test-compile-check:
     name: 'Test Compile Check'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -134,6 +163,7 @@ jobs:
 
   lint-tests:
     name: 'Lint Tests'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -153,6 +183,7 @@ jobs:
 
   unit-tests:
     name: 'Unit Tests'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -172,6 +203,7 @@ jobs:
 
   acceptance-tests:
     name: 'Acceptance Tests (No Relay)'
+    needs: enforce-fork-contribution
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18

--- a/.github/workflows/release-pr-ci.yml
+++ b/.github/workflows/release-pr-ci.yml
@@ -1,0 +1,117 @@
+name: Release PR CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  get-version:
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main' && github.actor == 'github-actions[bot]'
+    name: 'Get Release Version'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
+    steps:
+      - name: Extract Version from PR Title
+        id: extract-version
+        env:
+          RAW_PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          VERSION=$(echo "$RAW_PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "Extracted version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  release-test:
+    needs: get-version
+    name: 'Release Tests'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rancher/ci-image/nix:20260603-18
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        id: checkout-repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        id: setup-go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Run Unit Tests
+        id: run-unit-tests
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/test.sh unit
+      - name: Run All Acceptance Tests
+        id: run-acc-tests
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/test.sh acc-relay
+
+  rc-release:
+    needs:
+      - get-version
+      - release-test
+    name: 'RC Release'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rancher/ci-image/nix:20260603-18
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        id: checkout-repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Calculate RC Tag via API
+        id: create-push-rc-tag
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TARGET_VERSION: ${{ needs.get-version.outputs.version }}
+          CALCULATE_NEXT_RC: 'true'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
+            const { default: script } = await import(scriptPath);
+            await script({github, context, core, process});
+      - name: Create Local Tag
+        id: create-local-tag
+        env:
+          VERSION: ${{ steps.create-push-rc-tag.outputs.rc_tag }}
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-local-tag.sh "${{ steps.create-push-rc-tag.outputs.rc_tag }}"
+      - name: Retrieve GPG Credentials
+        id: retrieve-gpg-credentials
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # @main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
+            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
+            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
+      - name: Run GoReleaser
+        id: run-goreleaser
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
+          GPG_KEY: ${{ env.GPG_KEY }}
+          GORELEASER_CONFIG: .goreleaser_rc.yml
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/goreleaser.sh
+      - name: Publish RC Release
+        id: publish-rc-release
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ steps.create-push-rc-tag.outputs.rc_tag }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/publish-release.js`;
+            const { default: script } = await import(scriptPath);
+            await script({github, context, core, process});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ on:
 permissions: {}
 
 jobs:
-  release-please-release:
-    name: 'Release Please (Release Only)'
+  release-please:
+    name: 'Release Please'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -19,8 +19,9 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      version: ${{ steps.release-please-release.outputs.version }}
-      release_created: ${{ steps.release-please-release.outputs.release_created }}
+      version: ${{ steps.release-please.outputs.version || steps.release-please.outputs['.--version'] }}
+      release_created: ${{ steps.release-please.outputs.release_created }}
+      body: ${{ steps.release-please.outputs.body || steps.release-please.outputs['.--body'] }}
     steps:
       - name: Checkout Repository
         id: checkout-repository
@@ -29,216 +30,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Release Please (Release Only)
-        id: release-please-release
+      - name: Release Please
+        id: release-please
         # https://github.com/googleapis/release-please-action/releases
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
-          release-type: go
-          skip-github-pull-request: true
-
-  release-please-pr:
-    needs:
-      - release-please-release
-      - release
-    if: |
-      !cancelled() &&
-      needs.release-please-release.result == 'success' &&
-      (needs.release.result == 'success' || needs.release.result == 'skipped')
-    name: 'Release Please (PR Only)'
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/rancher/ci-image/nix:20260603-18
-    timeout-minutes: 30
-    permissions:
-      contents: write
-      pull-requests: write
-    outputs:
-      pr: ${{ steps.release-please-pr.outputs.pr || steps.release-please-pr.outputs['.--pr'] }}
-      version: ${{ steps.release-please-pr.outputs.version || steps.release-please-pr.outputs['.--version'] }}
-    steps:
-      - name: Checkout Repository
-        id: checkout-repository
-        # https://github.com/actions/checkout/releases
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-      - name: Release Please (PR Only)
-        id: release-please-pr
-        # https://github.com/googleapis/release-please-action/releases
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
-        with:
-          target-branch: ${{ github.ref_name }}
-          config-file: release-please-config.json
-          release-type: go
+          release-type: simple
           skip-github-release: true
-
-  # Release tests only run if release-please created or updated a PR
-  release-test:
-    needs: release-please-pr
-    if: needs.release-please-pr.outputs.pr != ''
-    name: 'Release Tests'
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/rancher/ci-image/nix:20260603-18
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      pull-requests: write
-    outputs:
-      outcome: ${{ steps.run-unit-tests.conclusion == 'success' && steps.run-acc-tests.conclusion == 'success' }}
-    steps:
-      - name: Checkout Repository
-        id: checkout-repository
-        # https://github.com/actions/checkout/releases
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-      - name: Wait for E2E
-        id: wait-for-e2e
-        # https://github.com/actions/github-script/releases
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          PR_NUMBER: ${{ fromJson(needs.release-please-pr.outputs.pr).number }}
-          GITHUB_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          COMMENT_BODY: "Please make sure e2e tests pass before merging this PR! \n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/post-pr-comment.js`;
-            const { default: script } = await import(scriptPath);
-            await script({github, context, core, process});
-      - name: Checkout Repository Again
-        id: checkout-repository-again
-        # https://github.com/actions/checkout/releases
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Setup Go
-        id: setup-go
-        # https://github.com/actions/setup-go/releases
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - name: Run Unit Tests
-        id: run-unit-tests
-        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/test.sh unit
-      - name: Run All Acceptance Tests
-        id: run-acc-tests
-        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/test.sh acc-relay
-      - name: Report Tests Passed
-        id: report-tests-passed
-        # https://github.com/actions/github-script/releases
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        if: always() && (steps.run-unit-tests.conclusion == 'success') && (steps.run-acc-tests.conclusion == 'success')
-        env:
-          PR_NUMBER: ${{ fromJson(needs.release-please-pr.outputs.pr).number }}
-          GITHUB_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          COMMENT_BODY: "Tests Passed!"
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/post-pr-comment.js`;
-            const { default: script } = await import(scriptPath);
-            await script({github, context, core, process});
-      - name: Report Tests Failed
-        id: report-tests-failed
-        # https://github.com/actions/github-script/releases
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        if: always() && ((steps.run-unit-tests.conclusion == 'failure') || (steps.run-acc-tests.conclusion == 'failure'))
-        env:
-          PR_NUMBER: ${{ fromJson(needs.release-please-pr.outputs.pr).number }}
-          GITHUB_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          COMMENT_BODY: "Tests Failed!"
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/post-pr-comment.js`;
-            const { default: script } = await import(scriptPath);
-            await script({github, context, core, process});
-
-  # This runs if release-please created or updated a PR, tests run and pass
-  rc-release:
-    needs:
-      - release-please-pr
-      - release-test
-    if: needs.release-please-pr.outputs.pr != '' && needs.release-test.outputs.outcome == 'true'
-    name: 'RC Release'
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/rancher/ci-image/nix:20260603-18
-    timeout-minutes: 30
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout Repository
-        id: checkout-repository
-        # https://github.com/actions/checkout/releases
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-      # If the e2e tests pass we automatically generate an RC release
-      #   this shouldn't happen when the release PR is merged, only when it's opened or updated
-      - name: Calculate RC Tag via API
-        id: create-push-rc-tag
-        # https://github.com/actions/github-script/releases
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          TARGET_VERSION: ${{ needs.release-please-pr.outputs.version }}
-          CALCULATE_NEXT_RC: 'true'
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
-            const { default: script } = await import(scriptPath);
-            await script({github, context, core, process});
-      - name: Create Local Tag
-        id: create-local-tag
-        env:
-          VERSION: ${{ steps.create-push-rc-tag.outputs.rc_tag }}
-        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-local-tag.sh "${{ steps.create-push-rc-tag.outputs.rc_tag }}"
-      - name: Retrieve GPG Credentials
-        id: retrieve-gpg-credentials
-        # https://github.com/rancher-eio/read-vault-secrets/commits
-        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
-            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
-            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
-      - name: Run GoReleaser
-        id: run-goreleaser
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
-          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-          GPG_KEY: ${{ env.GPG_KEY }}
-          GORELEASER_CONFIG: .goreleaser_rc.yml
-        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/goreleaser.sh
-      - name: Publish RC Release
-        id: publish-rc-release
-        # https://github.com/actions/github-script/releases
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          VERSION: ${{ steps.create-push-rc-tag.outputs.rc_tag }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/publish-release.js`;
-            const { default: script } = await import(scriptPath);
-            await script({github, context, core, process});
 
   # These run after release-please generates a release
   release:
     name: 'Full Release'
     needs:
-      - release-please-release
-    if: needs.release-please-release.outputs.release_created == 'true'
+      - release-please
+    if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
@@ -256,8 +63,8 @@ jobs:
       - name: Create Local Tag
         id: create-local-tag
         env:
-          VERSION: ${{ needs.release-please-release.outputs.version }}
-        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-local-tag.sh "${{ needs.release-please-release.outputs.version }}"
+          VERSION: ${{ needs.release-please.outputs.version }}
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-local-tag.sh "${{ needs.release-please.outputs.version }}"
       - name: Setup Go
         id: setup-go
         # https://github.com/actions/setup-go/releases
@@ -274,6 +81,12 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
+      - name: Save Release Notes
+        id: save-release-notes
+        env:
+          RELEASE_BODY: ${{ needs.release-please.outputs.body }}
+        run: |
+          printf "%s\n" "$RELEASE_BODY" > /tmp/release-notes.md
       - name: Run GoReleaser
         id: run-goreleaser
         env:
@@ -287,7 +100,7 @@ jobs:
         # https://github.com/actions/github-script/releases
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          VERSION: ${{ needs.release-please-release.outputs.version }}
+          VERSION: ${{ needs.release-please.outputs.version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/scripts/nix-run.sh
+++ b/.github/workflows/scripts/nix-run.sh
@@ -35,30 +35,6 @@ while [[ "${p}" != "/" && -n "${p}" ]]; do
 done
 
 sudo -E -u suse /home/suse/.nix-profile/bin/nix develop \
-  --ignore-environment \
   --extra-experimental-features nix-command \
   --extra-experimental-features flakes \
-  --keep NIX_SSL_CERT_FILE \
-  --keep SSL_CERT_FILE \
-  --keep CURL_CA_BUNDLE \
-  --keep NIX_ENV_LOADED \
-  --keep TERM \
-  --keep HOME \
-  --keep SSH_AUTH_SOCK \
-  --keep GITHUB_TOKEN \
-  --keep GITHUB_OWNER \
-  --keep AWS_ACCESS_KEY_ID \
-  --keep AWS_SECRET_ACCESS_KEY \
-  --keep AWS_SESSION_TOKEN \
-  --keep AWS_ROLE \
-  --keep AWS_REGION \
-  --keep AWS_DEFAULT_REGION \
-  --keep IDENTIFIER \
-  --keep ZONE \
-  --keep ACME_SERVER_URL \
-  --keep PR_NUMBER \
-  --keep GPG_PASSPHRASE \
-  --keep GPG_KEY_ID \
-  --keep GPG_KEY \
   --command bash -e .nix-script.sh
-  

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,5 +63,6 @@ release:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   draft: true
   use_existing_draft: true
+  release_notes_file: /tmp/release-notes.md
 changelog:
-  disable: true
+  disable: false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,19 +1,21 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "go",
+  "release-type": "simple",
   "prerelease": false,
   "draft": true,
   "force-tag-creation": true,
+  "skip-github-release": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "always-update": true,
   "initial-version": "v0.1.0",
   "packages": {
     ".": {
-      "release-type": "go",
+      "release-type": "simple",
       "draft": true,
       "prerelease": false,
       "force-tag-creation": true,
+      "skip-github-release": true,
       "include-v-in-tag": true
     }
   }


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
https://github.com/rancher/terraform-provider-file/actions/runs/30484038967
Release CI is failing.
Release-please keeps generating full releases when it should only be creating draft releases.
This disables release please from generating releases, instead it just writes to the changelog and tags.
GoReleaser then takes the changelog, copies it to the release notes, and generates a draft release. Then it builds and uploads the artifacts to the draft release. GoReleaser never publishes the release. After GoReleaser completes successfully an additional step will publish the release (using github-script).

A new CI will run only when a release PR is created, it runs release tests and generates an rc release.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint, shellcheck

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
