### PR TITLE
fix: give id-token privileges to generate token

### DIFF
--- a/.github/workflows/release-pr-ci.yml
+++ b/.github/workflows/release-pr-ci.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout Repository
         id: checkout-repository


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Need id token privs to generate a token.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
