### PR TITLE
fix: fix full release by properly collecting release please output

### DIFF
--- a/.agent/agent-memory/FixSkippedFullRelease_temp.md
+++ b/.agent/agent-memory/FixSkippedFullRelease_temp.md
@@ -1,0 +1,9 @@
+# Temporary Plan: Fix Skipped Full Release CI Failure
+
+**Executed Date:** 2026-07-29
+**Purpose:** Ensure the Full Release job triggers properly when a release pull request is merged by correctly capturing the `release_created` output from the `release-please` action in manifest mode.
+
+## Checklist
+
+- [x] Update `release_created` output mapping in `.github/workflows/release.yml`'s `release-please` job to check `steps.release-please.outputs['.--release_created']` as a fallback.
+- [x] Run `actionlint` locally to verify the updated workflow YAML syntax.

--- a/.agent/agent-memory/PLAN_LOG.md
+++ b/.agent/agent-memory/PLAN_LOG.md
@@ -1,21 +1,34 @@
 # Plan Log
 
-## ConsolidateWorkflowScripts
-- **Date:** 2026-07-22
-- **Purpose:** Consolidate redundant workflow scripts (such as tag creation and commenting), fix a critical unit-testing script naming bug in the PR workflow, and normalize all bash and javascript files to comply with repository standard styles (using double brackets `[[ ]]`, `set -euo pipefail`, explicit error redirection to stderr, `try/catch` wrapping, and paginate).
-
 ## WorkflowStandards
 - **Date:** 2026-07-20
 - **Purpose:** Update all workflows to have a standard step structure, extract all scripts so they can be linted, use commit hashes for action versioning, and implement least privilege security principle.
-
-## ReleaseFromMain
-- **Date:** 2026-07-16
-- **Purpose:** Update the release workflows and scripts so that the repository releases directly from the `main` branch instead of relying on `release/v*` branches. This simplifies the release strategy and aligns with a trunk-based development approach.
 
 ## ScaffoldAgenticEnvironment
 - **Date:** 2026-07-14
 - **Purpose:** Provide a reproducible blueprint for scaffolding a unified, cross-platform AI agentic environment in any new or existing repository.
 
+## ReleaseFromMain
+- **Date:** 2026-07-16
+- **Purpose:** Update the release workflows and scripts so that the repository releases directly from the `main` branch instead of relying on `release/v*` branches. This simplifies the release strategy and aligns with a trunk-based development approach.
+
+## FixSkippedFullRelease
+- **Date:** 2026-07-29
+- **Purpose:** Ensure the Full Release job triggers properly when a release pull request is merged by correctly capturing the `release_created` output from the `release-please` action in manifest mode.
+
+## FixGoReleaserGPGMismatch
+- **Date:** 2026-07-29
+- **Purpose:** Resolve the release workflow failure (`gpg: error reading key: No secret key`) caused by GPG_KEY_ID pointing to an encryption-only subkey or being mismatched with the imported primary secret signing key.
+
+## FixGoReleaserAndGPG
+- **Date:** 2026-07-28
+- **Purpose:** Fix the GoReleaser release workflow failure caused by an invalid `GPG_KEY_ID` lookup and remove broken references to deleted `.sh` files in the GitHub Actions workflows.
+
 ## ContextLimitEnforcementHook
 - **Date:** 2026-07-14
 - **Purpose:** Implement a generic CLI hook in `.agent/hooks/` to automatically monitor and enforce context limits (e.g., 200,000 tokens) for agents like Gemini and Claude, preventing them from exceeding maximum token sizes and degrading performance.
+
+## ConsolidateWorkflowScripts
+- **Date:** 2026-07-22
+- **Purpose:** Consolidate redundant workflow scripts (such as tag creation and commenting), fix a critical unit-testing script naming bug in the PR workflow, and normalize all bash and javascript files to comply with repository standard styles (using double brackets `[[ ]]`, `set -euo pipefail`, explicit error redirection to stderr, `try/catch` wrapping, and paginate).
+

--- a/.agent/plans/FixSkippedFullRelease.md
+++ b/.agent/plans/FixSkippedFullRelease.md
@@ -1,0 +1,17 @@
+# Plan: Fix Skipped Full Release CI Failure
+
+**Executed Date:** 2026-07-29
+**Purpose:** Ensure the Full Release job triggers properly when a release pull request is merged by correctly capturing the `release_created` output from the `release-please` action in manifest mode.
+
+## Background & Motivation
+The `Full Release` job in the `Release` workflow was being skipped because the `needs.release-please.outputs.release_created` condition was evaluating to false or empty. When `release-please-action` operates in manifest mode (with a `.packages` configuration block in `release-please-config.json`), it prefixes its step outputs with the path. As a result, it exports `.--release_created` rather than `release_created`. The job outputs configuration mapped `version` and `body` with path fallbacks, but missed `release_created`. Because the Full Release never ran, tags were not created on GitHub, causing `release-please` to not see the release and to continually try to re-release the same versions.
+
+## Implementation Steps
+
+1. **Update Workflow Outputs:**
+   * Modify the `outputs` block of the `release-please` job in `.github/workflows/release.yml`.
+   * Change `release_created: ${{ steps.release-please.outputs.release_created }}` to `release_created: ${{ steps.release-please.outputs.release_created || steps.release-please.outputs['.--release_created'] }}`.
+
+## Verification & Testing
+1. Run `actionlint` locally to ensure no YAML syntax errors are introduced.
+2. Confirm the syntax aligns with how `version` and `body` are handled in the same block.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     outputs:
       version: ${{ steps.release-please.outputs.version || steps.release-please.outputs['.--version'] }}
-      release_created: ${{ steps.release-please.outputs.release_created }}
+      release_created: ${{ steps.release-please.outputs.release_created || steps.release-please.outputs['.--release_created'] }}
       body: ${{ steps.release-please.outputs.body || steps.release-please.outputs['.--body'] }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
### Problem
 1. The repository's release-please config (release-please-config.json) is set up using manifest mode (via a packages block mapping ".").
 2. In manifest mode, the release-please-action prefixes all outputs with the path. For the root path ".", this results in an output of .--release_created instead of the standard release_created.
 3. In .github/workflows/release.yml, the job output mapping for release_created only listened to steps.release-please.outputs.release_created without any fallback.
 4. Because the output was empty, the Full Release job's conditional check if: needs.release-please.outputs.release_created == 'true' evaluated to false, skipping the tag creation, GoReleaser, and publication steps completely.

### Applied Resolution
 1. Workflow Update: Modified the outputs block in .github/workflows/release.yml to include the appropriate fallback:
     - release_created: `${{ steps.release-please.outputs.release_created || steps.release-please.outputs['.--release_created'] }}`
 2. Validation: Validated the updated workflow YAML using actionlint locally to guarantee correctness.
 3. Documentation: Logged the execution in .agent/plans/FixSkippedFullRelease.md, updated the tracking checklist in .agent/agent-memory/FixSkippedFullRelease_temp.md, and regenerated the global plan index in PLAN_LOG.md.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
