### PR TITLE
fix: move checkout higher in the manual release steps

### DIFF
--- a/.agent/agent-memory/FixManualReleaseWorkflows_temp.md
+++ b/.agent/agent-memory/FixManualReleaseWorkflows_temp.md
@@ -1,0 +1,10 @@
+# Temporary Plan: Fix Manual Release Workflows
+
+**Executed Date:** 2026-07-29
+**Purpose:** Resolve the `ERR_MODULE_NOT_FOUND` error in `manual-release.yml` and `manual-rc-release.yml` by ensuring the repository is checked out before any script execution steps are run.
+
+## Checklist
+
+- [x] In `.github/workflows/manual-release.yml`, move the `Checkout Repository` step to be the first step in the `release` job.
+- [x] In `.github/workflows/manual-rc-release.yml`, move the `Checkout Repository` step to be the first step in the `rc-release` job.
+- [x] Run `actionlint` locally to verify the updated workflow YAML syntax.

--- a/.agent/agent-memory/PLAN_LOG.md
+++ b/.agent/agent-memory/PLAN_LOG.md
@@ -16,6 +16,10 @@
 - **Date:** 2026-07-29
 - **Purpose:** Ensure the Full Release job triggers properly when a release pull request is merged by correctly capturing the `release_created` output from the `release-please` action in manifest mode.
 
+## FixManualReleaseWorkflows
+- **Date:** 2026-07-29
+- **Purpose:** Resolve the `ERR_MODULE_NOT_FOUND` error in `manual-release.yml` and `manual-rc-release.yml` by ensuring the repository is checked out before any script execution steps are run.
+
 ## FixGoReleaserGPGMismatch
 - **Date:** 2026-07-29
 - **Purpose:** Resolve the release workflow failure (`gpg: error reading key: No secret key`) caused by GPG_KEY_ID pointing to an encryption-only subkey or being mismatched with the imported primary secret signing key.

--- a/.agent/plans/FixManualReleaseWorkflows.md
+++ b/.agent/plans/FixManualReleaseWorkflows.md
@@ -1,0 +1,17 @@
+# Plan: Fix Manual Release Workflows
+
+**Executed Date:** 2026-07-29
+**Purpose:** Resolve the `ERR_MODULE_NOT_FOUND` error in `manual-release.yml` and `manual-rc-release.yml` by ensuring the repository is checked out before any script execution steps are run.
+
+## Background & Motivation
+The `manual-release.yml` and `manual-rc-release.yml` workflows were failing immediately upon execution with an `ERR_MODULE_NOT_FOUND` error. This occurred because the `Check User In Maintainers` and `Validate Release Tag` (or `Validate RC Tag`) steps attempted to execute scripts located in `.github/workflows/scripts/` prior to the `Checkout Repository` step running.
+
+## Implementation Steps
+
+1. **Reorder Steps in `manual-release.yml`:**
+   * Move the `actions/checkout` step (currently named "Checkout Repository") to be the first step in the `release` job's `steps:` array.
+2. **Reorder Steps in `manual-rc-release.yml`:**
+   * Move the `actions/checkout` step (currently named "Checkout Repository") to be the first step in the `rc-release` job's `steps:` array.
+
+## Verification & Testing
+1. Run `actionlint` locally to ensure no YAML syntax errors are introduced by reordering the steps.

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -29,6 +29,12 @@ jobs:
       pull-requests: write
       actions: read
     steps:
+      - name: 'Checkout Repository'
+        id: checkout
+        # https://github.com/actions/checkout/releases
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: 'Check User In Maintainers'
         id: check-user-in-maintainers
         # https://github.com/actions/github-script/releases
@@ -47,12 +53,6 @@ jobs:
           TAG: ${{ inputs.tag }}
           EXPECTED_TYPE: rc
         run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/validate-tag.sh
-      - name: 'Checkout Repository'
-        id: checkout
-        # https://github.com/actions/checkout/releases
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
       - name: Create and Push RC Tag via API
         id: create-push-rc-tag
         # https://github.com/actions/github-script/releases

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -23,6 +23,12 @@ jobs:
       id-token: write
       actions: read
     steps:
+      - name: 'Checkout Repository'
+        id: checkout
+        # https://github.com/actions/checkout/releases
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: 'Check User In Maintainers'
         id: check-user-in-maintainers
         # https://github.com/actions/github-script/releases
@@ -41,12 +47,6 @@ jobs:
           TAG: ${{ inputs.tag }}
           EXPECTED_TYPE: release
         run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/validate-tag.sh
-      - name: 'Checkout Repository'
-        id: checkout
-        # https://github.com/actions/checkout/releases
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
       - name: 'Create and Push Tag via API'
         id: create-push-tag
         # https://github.com/actions/github-script/releases


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Manual release is failing: https://github.com/rancher/terraform-provider-file/actions/runs/26118346179
Moving the checkout action to the first step to resolve.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
