### PR TITLE
fix: resolve tagging issues in the manual release workflow

### DIFF
--- a/.agent/agent-memory/FixManualWorkflowTagCreation_temp.md
+++ b/.agent/agent-memory/FixManualWorkflowTagCreation_temp.md
@@ -1,0 +1,15 @@
+# Temporary Plan: Fix Manual Workflow Tag Creation
+
+**Executed Date:** 2026-07-29
+**Purpose:** Update `.github/workflows/scripts/create-push-tag.js` to correctly handle pre-existing tags (with SHA validation) and re-introduce optional tag creation for manual workflows using a `CREATE_REF` environment variable.
+
+## Checklist
+
+- [x] Modify `.github/workflows/scripts/create-push-tag.js`:
+  - Enhance `tagExists` block: If tag exists, compare the remote tag's object SHA to the provided `sha`. Fail if they differ. If they match, skip creation and continue.
+  - Re-add `github.rest.git.createRef` logic.
+  - Wrap `createRef` in `if (process.env.CREATE_REF === 'true')`.
+- [x] Modify `.github/workflows/manual-release.yml` to inject `CREATE_REF: 'true'` into the `Create and Push Tag via API` step.
+- [x] Modify `.github/workflows/manual-rc-release.yml` to inject `CREATE_REF: 'true'` into the `Create and Push RC Tag via API` step.
+- [x] Validate JavaScript changes visually for logic errors.
+- [x] Run `actionlint` locally to verify YAML workflow changes.

--- a/.agent/plans/FixManualWorkflowTagCreation.md
+++ b/.agent/plans/FixManualWorkflowTagCreation.md
@@ -1,0 +1,28 @@
+# Plan: Fix Manual Workflow Tag Creation
+
+**Executed Date:** 2026-07-29
+**Purpose:** Update `.github/workflows/scripts/create-push-tag.js` to correctly handle pre-existing tags (with SHA validation) and re-introduce optional tag creation for manual workflows using a `CREATE_REF` environment variable.
+
+## Background & Motivation
+The manual release workflows failed at the `Checkout New Tag` step because the preceding step (`create-push-tag.js`) no longer creates the git tag on the remote repository. This tag creation logic was stripped in PR #354 to prevent test workflows from accidentally pushing tags to the repository. Additionally, when a tag *already* exists on the remote (e.g., pushed manually by a developer to unblock CI), the manual release workflows should be resilient enough to detect it, validate it, and gracefully proceed rather than failing or erroring out.
+
+## Proposed Solution
+We will update `create-push-tag.js` to intelligently handle tag existence and conditional creation:
+1. **Existing Tag Validation:** If the tag already exists, the script will fetch its SHA. If the workflow provided a specific `SHA` to build from, it will compare the two. If they do not match, the script will fail. If they do match (or no target SHA was forced), it safely skips creation and continues to output the tag.
+2. **Conditional Creation:** If the tag does not exist, the script will create it via the API (`github.rest.git.createRef`) **only** if the `CREATE_REF` environment variable is set to `'true'`.
+3. **Workflow Integration:** We will configure `manual-release.yml` and `manual-rc-release.yml` to pass `CREATE_REF: 'true'`, ensuring they can generate tags when required, while other CI pipelines remain safe.
+
+## Implementation Steps
+
+1. **Update `create-push-tag.js`:**
+   * Fetch the existing tag's target SHA via `github.rest.git.getRef`.
+   * Compare `existingRef.data.object.sha` to the provided `sha`.
+   * Add the `createRef` block wrapped in an `if (process.env.CREATE_REF === 'true')` statement.
+2. **Update `manual-release.yml`:**
+   * Add `CREATE_REF: 'true'` to the `Create and Push Tag via API` step's environment block.
+3. **Update `manual-rc-release.yml`:**
+   * Add `CREATE_REF: 'true'` to the `Create and Push RC Tag via API` step's environment block.
+
+## Verification & Testing
+1. Visually review the JavaScript logic to ensure error handling (`try/catch`) is robust.
+2. Run `actionlint` locally to verify the YAML modifications.

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -60,6 +60,7 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
           SHA: ${{ inputs.sha }}
+          CREATE_REF: 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
           SHA: ${{ inputs.sha }}
+          CREATE_REF: 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/scripts/create-push-tag.js
+++ b/.github/workflows/scripts/create-push-tag.js
@@ -52,13 +52,24 @@ export default async ({ github, context, core, process }) => {
 
     // Check if tag already exists using the API
     let tagExists = false;
+    let existingSha = "";
     try {
-      await github.rest.git.getRef({
+      const existingRef = await github.rest.git.getRef({
         owner,
         repo,
         ref: `tags/${targetTag}`,
       });
       tagExists = true;
+      existingSha = existingRef.data.object.sha;
+      if (existingRef.data.object.type === 'tag') {
+        core.info(`Tag ${targetTag} is annotated. Fetching target commit SHA...`);
+        const annotatedTag = await github.rest.git.getTag({
+          owner,
+          repo,
+          tag_sha: existingRef.data.object.sha,
+        });
+        existingSha = annotatedTag.data.object.sha;
+      }
     } catch (error) {
       if (error.status !== 404) {
         throw error;
@@ -66,11 +77,30 @@ export default async ({ github, context, core, process }) => {
     }
 
     if (tagExists) {
-      core.info(`Tag ${targetTag} already exists on remote.`);
+      core.info(`Tag ${targetTag} already exists on remote pointing to SHA ${existingSha}.`);
+      if (sha) {
+        if (existingSha !== sha) {
+          throw new Error(`Tag ${targetTag} already exists on remote pointing to SHA ${existingSha}, but requested SHA is ${sha}. Mismatch!`);
+        } else {
+          core.info(`Existing tag SHA matches the requested SHA ${sha}. Proceeding gracefully.`);
+        }
+      }
       if (calculateNextRc) {
         throw new Error(`Calculated RC tag ${targetTag} already exists on remote. This should not happen.`);
       }
-      return;
+    } else {
+      if (process.env.CREATE_REF === 'true') {
+        core.info(`Creating tag ref refs/tags/${targetTag} pointing to ${sha}...`);
+        await github.rest.git.createRef({
+          owner,
+          repo,
+          ref: `refs/tags/${targetTag}`,
+          sha,
+        });
+        core.info(`Successfully created tag ${targetTag}`);
+      } else {
+        core.info(`Tag ${targetTag} does not exist on remote and CREATE_REF is not true. Skipping tag creation.`);
+      }
     }
 
     // Set outputs for downstream steps if needed


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
The manual release workflows failed at the `Checkout New Tag` step because the preceding step (`create-push-tag.js`) no longer creates the git tag on the remote repository. This tag creation logic was stripped in PR #354 to prevent test workflows from accidentally pushing tags to the repository. Additionally, when a tag *already* exists on the remote (e.g., pushed manually by a developer to unblock CI), the manual release workflows should be resilient enough to detect it, validate it, and gracefully proceed rather than failing or erroring out.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
