### PR TITLE
fix: push tag in separate script for manual release

### DIFF
--- a/.agent/agent-memory/EnforceReleasePleaseValidation_temp.md
+++ b/.agent/agent-memory/EnforceReleasePleaseValidation_temp.md
@@ -1,0 +1,10 @@
+# Temporary Plan: Enforce Release Please Output Validation
+
+**Executed Date:** 2026-07-29
+**Purpose:** Prevent silent failures by enforcing that the `release-please` job in `.github/workflows/release.yml` fails if it does not create a release or a pull request.
+
+## Checklist
+
+- [x] Add `Verify Release Please Action` step immediately after the `Release Please` step in `.github/workflows/release.yml`.
+- [x] Implement `bash` script in the step to check `RELEASE_CREATED` and `PR` environment variables (using appropriate manifest path fallbacks), and exit with `1` if both are empty/false.
+- [x] Run `actionlint` to ensure valid YAML structure.

--- a/.agent/agent-memory/FixTagCreationPermissions_temp.md
+++ b/.agent/agent-memory/FixTagCreationPermissions_temp.md
@@ -5,10 +5,10 @@
 
 ## Checklist
 
-- [ ] Write a new Bash script `.github/workflows/scripts/create-push-tag.sh` that uses `git ls-remote` and `git push origin <tag>` to create/verify tags.
-- [ ] Ensure the script enforces the same pre-existing tag SHA validation rules as the Javascript version.
-- [ ] Replace the `Create and Push Tag via API` step in `.github/workflows/manual-release.yml` with a step executing the new bash script.
-- [ ] Replace the `Create and Push RC Tag via API` step in `.github/workflows/manual-rc-release.yml` with a step executing the new bash script.
-- [ ] Revert `create-push-tag.js` back to its original state (as it was after PR #354) since manual workflows will no longer use it for tag creation.
-- [ ] Run `shellcheck` on the new bash script.
-- [ ] Run `actionlint` on the updated YAML workflows.
+- [x] Write a new Bash script `.github/workflows/scripts/create-push-tag.sh` that uses `git ls-remote` and `git push origin <tag>` to create/verify tags.
+- [x] Ensure the script enforces the same pre-existing tag SHA validation rules as the Javascript version.
+- [x] Replace the `Create and Push Tag via API` step in `.github/workflows/manual-release.yml` with a step executing the new bash script.
+- [x] Replace the `Create and Push RC Tag via API` step in `.github/workflows/manual-rc-release.yml` with a step executing the new bash script.
+- [x] Revert `create-push-tag.js` back to its original state (as it was after PR #354) since manual workflows will no longer use it for tag creation.
+- [x] Run `shellcheck` on the new bash script.
+- [x] Run `actionlint` on the updated YAML workflows.

--- a/.agent/agent-memory/FixTagCreationPermissions_temp.md
+++ b/.agent/agent-memory/FixTagCreationPermissions_temp.md
@@ -1,0 +1,14 @@
+# Temporary Plan: Fix Tag Creation Permissions
+
+**Executed Date:** 2026-07-29
+**Purpose:** Replace the `actions/github-script` tag creation steps in manual workflows with standard `git` CLI commands to bypass GitHub API restrictions on tagging historical commits without `workflows: write` permissions.
+
+## Checklist
+
+- [ ] Write a new Bash script `.github/workflows/scripts/create-push-tag.sh` that uses `git ls-remote` and `git push origin <tag>` to create/verify tags.
+- [ ] Ensure the script enforces the same pre-existing tag SHA validation rules as the Javascript version.
+- [ ] Replace the `Create and Push Tag via API` step in `.github/workflows/manual-release.yml` with a step executing the new bash script.
+- [ ] Replace the `Create and Push RC Tag via API` step in `.github/workflows/manual-rc-release.yml` with a step executing the new bash script.
+- [ ] Revert `create-push-tag.js` back to its original state (as it was after PR #354) since manual workflows will no longer use it for tag creation.
+- [ ] Run `shellcheck` on the new bash script.
+- [ ] Run `actionlint` on the updated YAML workflows.

--- a/.agent/agent-memory/PLAN_LOG.md
+++ b/.agent/agent-memory/PLAN_LOG.md
@@ -16,6 +16,10 @@
 - **Date:** 2026-07-29
 - **Purpose:** Ensure the Full Release job triggers properly when a release pull request is merged by correctly capturing the `release_created` output from the `release-please` action in manifest mode.
 
+## FixManualWorkflowTagCreation
+- **Date:** 2026-07-29
+- **Purpose:** Update `.github/workflows/scripts/create-push-tag.js` to correctly handle pre-existing tags (with SHA validation) and re-introduce optional tag creation for manual workflows using a `CREATE_REF` environment variable.
+
 ## FixManualReleaseWorkflows
 - **Date:** 2026-07-29
 - **Purpose:** Resolve the `ERR_MODULE_NOT_FOUND` error in `manual-release.yml` and `manual-rc-release.yml` by ensuring the repository is checked out before any script execution steps are run.
@@ -27,6 +31,10 @@
 ## FixGoReleaserAndGPG
 - **Date:** 2026-07-28
 - **Purpose:** Fix the GoReleaser release workflow failure caused by an invalid `GPG_KEY_ID` lookup and remove broken references to deleted `.sh` files in the GitHub Actions workflows.
+
+## EnforceReleasePleaseValidation
+- **Date:** 2026-07-29
+- **Purpose:** Prevent silent failures by enforcing that the `release-please` job in `.github/workflows/release.yml` fails if it does not create a release or a pull request.
 
 ## ContextLimitEnforcementHook
 - **Date:** 2026-07-14

--- a/.agent/plans/EnforceReleasePleaseValidation.md
+++ b/.agent/plans/EnforceReleasePleaseValidation.md
@@ -1,0 +1,17 @@
+# Plan: Enforce Release Please Output Validation
+
+**Executed Date:** 2026-07-29
+**Purpose:** Prevent silent failures by enforcing that the `release-please` job in `.github/workflows/release.yml` fails if it does not create a release or a pull request.
+
+## Background & Motivation
+Currently, `release-please-action` can encounter states where it safely aborts without taking any action (e.g., "There are untagged, merged release PRs outstanding - aborting"). Because it exits with a successful `0` status code, the GitHub Actions pipeline displays a green checkmark, hiding the fact that releases and changelogs are completely stalled. Given the strict Conventional Commits enforcement in this repository, any push to `main` must result in either a new release (if the release PR was merged) or an updated release PR (if any other PR was merged).
+
+## Implementation Steps
+
+1. **Add Validation Step:**
+   * Append a new step named `Verify Release Please Action` directly after the `Release Please` step in the `release-please` job in `.github/workflows/release.yml`.
+   * Capture the `release_created` and `pr` outputs into environment variables, utilizing the `||` operator to accommodate manifest-mode outputs (`.--release_created` and `.--pr`).
+   * Write a short inline bash script that verifies at least one of these variables is populated. If both evaluate to false or empty, echo an explanatory error message and `exit 1`.
+
+## Verification & Testing
+1. Run `actionlint` locally to guarantee the step syntax and workflow YAML remain valid.

--- a/.agent/plans/FixTagCreationPermissions.md
+++ b/.agent/plans/FixTagCreationPermissions.md
@@ -1,0 +1,27 @@
+# Plan: Fix Tag Creation Permissions
+
+**Executed Date:** 2026-07-29
+**Purpose:** Replace the `actions/github-script` tag creation steps in manual workflows with standard `git` CLI commands to bypass GitHub API restrictions on tagging historical commits without `workflows: write` permissions.
+
+## Background & Motivation
+When attempting to tag historical commits (SHAs other than the branch HEAD) using the GitHub REST API (`github.rest.git.createRef`), the API demands the `workflows: write` permission. The standard `GITHUB_TOKEN` is prohibited from holding this permission for security reasons, resulting in a `403 Resource not accessible by integration` error. To bypass this, we can rely on standard Git CLI commands (`git tag` and `git push`). Since the `actions/checkout` step already provisions the local Git configuration with the standard `contents: write` token, local tagging and pushing will succeed flawlessly regardless of commit age.
+
+## Implementation Steps
+
+1. **Create `create-push-tag.sh`:**
+   * Create a new bash script under `.github/workflows/scripts/`.
+   * Accept `TAG` and `SHA` environment variables.
+   * Check if the tag exists on the remote using `git ls-remote --tags origin "refs/tags/${TAG}"`.
+   * If it exists, fetch the remote tag and verify its target commit SHA matches the requested `SHA`.
+   * If it does not exist, run `git tag "${TAG}" "${SHA}"` followed by `git push origin "${TAG}"`.
+
+2. **Update Manual Workflows:**
+   * Modify `.github/workflows/manual-release.yml` and `.github/workflows/manual-rc-release.yml`.
+   * Replace the `actions/github-script` step that calls `create-push-tag.js` with a `run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-push-tag.sh` step.
+
+3. **Cleanup `create-push-tag.js`:**
+   * Since manual workflows are moving to the Bash script, we will revert `create-push-tag.js` to its upstream state (which purely calculates and reads tags for PR tests), removing the temporary `CREATE_REF` logic we added earlier.
+
+## Verification & Testing
+1. Run `shellcheck` on `.github/workflows/scripts/create-push-tag.sh`.
+2. Run `actionlint` on `.github/workflows/manual-release.yml` and `.github/workflows/manual-rc-release.yml`.

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -53,20 +53,12 @@ jobs:
           TAG: ${{ inputs.tag }}
           EXPECTED_TYPE: rc
         run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/validate-tag.sh
-      - name: Create and Push RC Tag via API
+      - name: 'Create and Push RC Tag'
         id: create-push-rc-tag
-        # https://github.com/actions/github-script/releases
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TAG: ${{ inputs.tag }}
-          SHA: ${{ inputs.sha }}
-          CREATE_REF: 'true'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
-            const { default: script } = await import(scriptPath);
-            await script({github, context, core, process});
+          SHA: ${{ inputs.sha || github.sha }}
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-push-tag.sh
       - name: 'Checkout New Tag'
         id: checkout-new-tag
         # https://github.com/actions/checkout/releases

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -47,20 +47,12 @@ jobs:
           TAG: ${{ inputs.tag }}
           EXPECTED_TYPE: release
         run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/validate-tag.sh
-      - name: 'Create and Push Tag via API'
+      - name: 'Create and Push Tag'
         id: create-push-tag
-        # https://github.com/actions/github-script/releases
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TAG: ${{ inputs.tag }}
-          SHA: ${{ inputs.sha }}
-          CREATE_REF: 'true'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-push-tag.js`;
-            const { default: script } = await import(scriptPath);
-            await script({github, context, core, process});
+          SHA: ${{ inputs.sha || github.sha }}
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/create-push-tag.sh
       - name: 'Checkout New Tag'
         id: checkout-new-tag
         # https://github.com/actions/checkout/releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,19 @@ jobs:
           release-type: simple
           skip-github-release: true
 
+      - name: Verify Release Please Action
+        id: verify-release-please
+        env:
+          RELEASE_CREATED: ${{ steps.release-please.outputs.release_created || steps.release-please.outputs['.--release_created'] }}
+          PR: ${{ steps.release-please.outputs.pr || steps.release-please.outputs['.--pr'] }}
+        run: |
+          if [[ "${RELEASE_CREATED}" != "true" && -z "${PR}" ]]; then
+            echo "Error: Release Please did not create a release and did not create or update any pull request." >&2
+            echo "This usually indicates that release-please aborted internally or encountered an issue (e.g. outstanding untagged merged PRs)." >&2
+            exit 1
+          fi
+          echo "Release Please completed successfully (Release Created: ${RELEASE_CREATED}, PR: ${PR})"
+
   # These run after release-please generates a release
   release:
     name: 'Full Release'

--- a/.github/workflows/scripts/create-push-tag.sh
+++ b/.github/workflows/scripts/create-push-tag.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# create-push-tag.sh - Create and push a git tag to remote repository.
+# Conforms to shell-scripts.instructions.md guidelines.
+
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "Error: TAG environment variable is required." >&2
+  exit 1
+fi
+
+if [[ -z "${SHA:-}" ]]; then
+  echo "Error: SHA environment variable is required." >&2
+  exit 1
+fi
+
+# Configure git identity for Actions bot
+git config --global user.name "github-actions[bot]"
+git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+echo "Checking if tag ${TAG} exists on remote..."
+# Fetch the tag ref from remote if it exists to verify
+if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+  echo "Tag ${TAG} already exists on remote. Verifying commit SHA..."
+  
+  # Fetch the tag locally so we can resolve its underlying commit SHA (annotated or lightweight)
+  git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --depth=1 --no-tags --quiet
+  
+  existing_sha=$(git rev-list -n 1 "${TAG}")
+  target_sha=$(git rev-list -n 1 "${SHA}")
+  
+  if [[ "${existing_sha}" != "${target_sha}" ]]; then
+    echo "Error: Tag ${TAG} already exists on remote pointing to commit ${existing_sha}, but requested SHA is ${target_sha}. Mismatch!" >&2
+    exit 1
+  else
+    echo "Success: Existing tag SHA matches requested SHA (${target_sha}). Proceeding gracefully."
+  fi
+else
+  echo "Tag ${TAG} does not exist on remote. Creating tag locally pointing to ${SHA}..."
+  git tag "${TAG}" "${SHA}"
+  
+  echo "Pushing tag ${TAG} to origin..."
+  git push origin "${TAG}"
+  echo "Successfully created and pushed tag ${TAG}."
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,7 @@ Tool use MUST prioritize built in tools and skills over shell, shell commands ar
 * **WebFetch:** When fetching web content always use the built in "Webfetch" tool, not curl on the command line.
 * **Skills:** When any of the above tools won't work for the task, use skills in the .agent/skills directory before crafting your own commands.
 * **Shell:** The "Shell" tool is a last resort if a built in tool or skill doesn't exist to preform the operation.
+
+## 7. Git & Source Control Rules
+
+* **No Commits or Pushes:** AI agents MUST NEVER stage, commit, or push changes to the repository under any circumstances. All changes must be left as unstaged modifications in the working tree so that the developer can review, stage, commit, and push them manually.


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Force release ci to fail if release please is unable to update a pr, create a pr, or create a tag.

Fix permissions issue with the manual release ci, more information in .agent/plans/FixTagCreationPermissions.md


## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint, shellcheck

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
