### PR TITLE
fix: fix tag verification in tag creation for manual release

### DIFF
--- a/.github/workflows/scripts/create-push-tag.sh
+++ b/.github/workflows/scripts/create-push-tag.sh
@@ -19,25 +19,25 @@ fi
 git config --global user.name "github-actions[bot]"
 git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-echo "Checking if tag ${TAG} exists on remote..."
-# Fetch the tag ref from remote if it exists to verify
-if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
-  echo "Tag ${TAG} already exists on remote. Verifying commit SHA..."
+echo "Checking if tag ${TAG} exists..."
+# Check if the tag exists locally or on the remote origin
+if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1 || (git ls-remote --tags origin 2>/dev/null | grep -q "refs/tags/${TAG}"); then
+  echo "Tag ${TAG} already exists (locally or on remote). Verifying commit SHA..."
   
-  # Fetch the tag locally so we can resolve its underlying commit SHA (annotated or lightweight)
-  git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --depth=1 --no-tags --quiet
+  # Quietly fetch the tag ref from remote if we don't have it locally or to ensure it's up to date
+  git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --depth=1 --no-tags --quiet || true
   
   existing_sha=$(git rev-list -n 1 "${TAG}")
   target_sha=$(git rev-list -n 1 "${SHA}")
   
   if [[ "${existing_sha}" != "${target_sha}" ]]; then
-    echo "Error: Tag ${TAG} already exists on remote pointing to commit ${existing_sha}, but requested SHA is ${target_sha}. Mismatch!" >&2
+    echo "Error: Tag ${TAG} exists pointing to commit ${existing_sha}, but requested SHA is ${target_sha}. Mismatch!" >&2
     exit 1
   else
     echo "Success: Existing tag SHA matches requested SHA (${target_sha}). Proceeding gracefully."
   fi
 else
-  echo "Tag ${TAG} does not exist on remote. Creating tag locally pointing to ${SHA}..."
+  echo "Tag ${TAG} does not exist. Creating tag locally pointing to ${SHA}..."
   git tag "${TAG}" "${SHA}"
   
   echo "Pushing tag ${TAG} to origin..."


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
https://github.com/rancher/terraform-provider-file/actions/runs/30508595641/job/90763618245
Manual release is failing because the tag already exists, this should correct.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
