### PR TITLE
fix: add a new goreleaser config for manual releases

### DIFF
--- a/.agent/agent-memory/FixManualGoReleaserConfig_temp.md
+++ b/.agent/agent-memory/FixManualGoReleaserConfig_temp.md
@@ -1,0 +1,11 @@
+# Temporary Plan: Fix Manual GoReleaser Config
+
+**Executed Date:** 2026-07-30
+**Purpose:** Create a dedicated GoReleaser configuration for the `manual-release.yml` workflow to prevent failures caused by missing release note files.
+
+## Checklist
+
+- [x] Copy `.goreleaser.yml` to `.goreleaser_manual.yml`.
+- [x] In `.goreleaser_manual.yml`, remove `use_existing_draft: true` and `release_notes_file: /tmp/release-notes.md` from the `release` block.
+- [x] Update `.github/workflows/manual-release.yml` to set `GORELEASER_CONFIG: ../../.goreleaser_manual.yml` in the `Run GoReleaser` step.
+- [x] Run `actionlint` locally to verify the updated workflow YAML syntax.

--- a/.agent/agent-memory/PLAN_LOG.md
+++ b/.agent/agent-memory/PLAN_LOG.md
@@ -12,6 +12,10 @@
 - **Date:** 2026-07-16
 - **Purpose:** Update the release workflows and scripts so that the repository releases directly from the `main` branch instead of relying on `release/v*` branches. This simplifies the release strategy and aligns with a trunk-based development approach.
 
+## FixTagCreationPermissions
+- **Date:** 2026-07-29
+- **Purpose:** Replace the `actions/github-script` tag creation steps in manual workflows with standard `git` CLI commands to bypass GitHub API restrictions on tagging historical commits without `workflows: write` permissions.
+
 ## FixSkippedFullRelease
 - **Date:** 2026-07-29
 - **Purpose:** Ensure the Full Release job triggers properly when a release pull request is merged by correctly capturing the `release_created` output from the `release-please` action in manifest mode.
@@ -23,6 +27,10 @@
 ## FixManualReleaseWorkflows
 - **Date:** 2026-07-29
 - **Purpose:** Resolve the `ERR_MODULE_NOT_FOUND` error in `manual-release.yml` and `manual-rc-release.yml` by ensuring the repository is checked out before any script execution steps are run.
+
+## FixManualGoReleaserConfig
+- **Date:** 2026-07-30
+- **Purpose:** Create a dedicated GoReleaser configuration for the `manual-release.yml` workflow to prevent failures caused by missing release note files.
 
 ## FixGoReleaserGPGMismatch
 - **Date:** 2026-07-29

--- a/.agent/plans/FixManualGoReleaserConfig.md
+++ b/.agent/plans/FixManualGoReleaserConfig.md
@@ -1,0 +1,22 @@
+# Plan: Fix Manual GoReleaser Config
+
+**Executed Date:** 2026-07-30
+**Purpose:** Create a dedicated GoReleaser configuration for the `manual-release.yml` workflow to prevent failures caused by missing release note files.
+
+## Background & Motivation
+The `manual-release.yml` workflow has been failing during the `Run GoReleaser` step. The standard `.goreleaser.yml` configuration includes `release_notes_file: /tmp/release-notes.md`. In automated release runs, the `release-please` action generates this file before GoReleaser is invoked. However, in a manual run, `release-please` is skipped, the file does not exist, and GoReleaser aborts the build.
+
+## Proposed Solution
+We will create a specific `.goreleaser_manual.yml` configuration file specifically for the manual release workflow. This file will be identical to `.goreleaser.yml` but will omit the `release_notes_file` and `use_existing_draft` directives. This will allow GoReleaser to successfully build, sign, and draft the release using its default, automatic git-log changelog generation.
+
+## Implementation Steps
+
+1. **Create `.goreleaser_manual.yml`:**
+   * Duplicate `.goreleaser.yml`.
+   * Under the `release:` block, remove `use_existing_draft: true` and `release_notes_file: /tmp/release-notes.md`.
+2. **Update `manual-release.yml`:**
+   * Modify the `Run GoReleaser` step's environment variables.
+   * Change `GORELEASER_CONFIG: ../../.goreleaser.yml` to `GORELEASER_CONFIG: ../../.goreleaser_manual.yml`.
+
+## Verification & Testing
+1. Run `actionlint` on `.github/workflows/manual-release.yml` to ensure YAML correctness.

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -93,7 +93,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           WORKING_DIR: ${{ github.workspace }}/tags/${{ inputs.tag }}
           SKIP_VALIDATE: true
-          GORELEASER_CONFIG: ../../.goreleaser.yml
+          GORELEASER_CONFIG: ../../.goreleaser_manual.yml
         run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/goreleaser.sh
       - name: 'Publish Release'
         id: publish-release

--- a/.goreleaser_manual.yml
+++ b/.goreleaser_manual.yml
@@ -1,0 +1,64 @@
+# https://goreleaser.com for documentation
+
+version: 2
+before:
+  hooks:
+    - go mod tidy
+git:
+  ignore_tags:
+    - "*rc*"
+builds:
+  - binary: '{{ .ProjectName }}_v{{ .Version }}'
+    env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like HCP Terraform where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm
+archives:
+  - formats: [ 'zip' ]
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    cmd: gpg
+    args:
+      - "--detach-sign"
+      - "--pinentry-mode"
+      - "loopback"
+      - "--passphrase"
+      - "{{ .Env.GPG_PASSPHRASE }}"
+      - "--local-user"
+      - "{{ .Env.GPG_KEY_ID }}"
+      - "--output"
+      - "${signature}"
+      - "--sign"
+      - "${artifact}"
+release:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  draft: true
+changelog:
+  disable: false


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Manual release Ci is failing: 
https://github.com/rancher/terraform-provider-file/actions/runs/30509462044/job/90766187824

This should resolve by using a new goreleaser config that doesn't depend on release-please.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
