### PR TITLE
fix: give goreleaser full tag history

### DIFF
--- a/.agent/agent-memory/FixShallowCloneTagCheckout_temp.md
+++ b/.agent/agent-memory/FixShallowCloneTagCheckout_temp.md
@@ -1,0 +1,10 @@
+# Temporary Plan: Fix Shallow Clone in Tag Checkout
+
+**Executed Date:** 2026-07-30
+**Purpose:** Prevent GoReleaser from creating `untagged` releases by ensuring the `Checkout New Tag` step clones the repository with its complete git tag history.
+
+## Checklist
+
+- [x] Modify `.github/workflows/manual-release.yml`: Add `fetch-depth: 0` to the `Checkout New Tag` step.
+- [x] Modify `.github/workflows/manual-rc-release.yml`: Add `fetch-depth: 0` to the `Checkout New Tag` step.
+- [x] Run `actionlint` locally to verify the updated workflow YAML syntax.

--- a/.agent/agent-memory/PLAN_LOG.md
+++ b/.agent/agent-memory/PLAN_LOG.md
@@ -20,6 +20,10 @@
 - **Date:** 2026-07-29
 - **Purpose:** Ensure the Full Release job triggers properly when a release pull request is merged by correctly capturing the `release_created` output from the `release-please` action in manifest mode.
 
+## FixShallowCloneTagCheckout
+- **Date:** 2026-07-30
+- **Purpose:** Prevent GoReleaser from creating `untagged` releases by ensuring the `Checkout New Tag` step clones the repository with its complete git tag history.
+
 ## FixManualWorkflowTagCreation
 - **Date:** 2026-07-29
 - **Purpose:** Update `.github/workflows/scripts/create-push-tag.js` to correctly handle pre-existing tags (with SHA validation) and re-introduce optional tag creation for manual workflows using a `CREATE_REF` environment variable.

--- a/.agent/plans/FixShallowCloneTagCheckout.md
+++ b/.agent/plans/FixShallowCloneTagCheckout.md
@@ -1,0 +1,22 @@
+# Plan: Fix Shallow Clone in Tag Checkout
+
+**Executed Date:** 2026-07-30
+**Purpose:** Prevent GoReleaser from creating `untagged` releases by ensuring the `Checkout New Tag` step clones the repository with its complete git tag history.
+
+## Background & Motivation
+The manual release workflows use `actions/checkout` to clone the target tag into a separate directory (`tags/${TAG}`) for GoReleaser to build from. By default, `actions/checkout` performs a shallow clone of depth 1, meaning it checks out the exact commit files but *does not fetch git tags*. When GoReleaser runs, it queries the local git repository to determine the version context. Because the repository lacks tags, GoReleaser panics, logs `couldn't find any tags before "v2.4.15"`, and creates a draft release on GitHub with a dummy name like `untagged-ce7804ebd7edb22cf1dd`. The subsequent `Publish Release` script then fails because it searches GitHub for a draft named `v2.4.15` and cannot find it.
+
+## Proposed Solution
+We will add `fetch-depth: 0` to the `Checkout New Tag` step in both `manual-release.yml` and `manual-rc-release.yml`. This forces the GitHub Action to fetch all history and tags, ensuring the cloned workspace is fully aware of the git tag context. GoReleaser will then correctly identify the tag, name the draft release properly, and allow the publish script to succeed.
+
+## Implementation Steps
+
+1. **Update `manual-release.yml`:**
+   * Locate the `Checkout New Tag` step.
+   * Add `fetch-depth: 0` to the `with:` block.
+2. **Update `manual-rc-release.yml`:**
+   * Locate the `Checkout New Tag` step.
+   * Add `fetch-depth: 0` to the `with:` block.
+
+## Verification & Testing
+1. Run `actionlint` on both modified `.yml` files to ensure syntax validity.

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           path: tags/${{ inputs.tag }}
+          fetch-depth: 0
       - name: 'Prepare Release Directory'
         id: prepare-release-dir
         env:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           path: tags/${{ inputs.tag }}
+          fetch-depth: 0
       - name: 'Prepare Release Directory'
         id: prepare-release-dir
         env:


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
https://github.com/rancher/terraform-provider-file/actions/runs/30510372707
Manual release fails to publish due to how Goreleaser created the release. 




## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
