### PR TITLE
fix: update readme with process for releasing workflow changes

### DIFF
--- a/.agent/agent-memory/FixGoReleaserTagContext_temp.md
+++ b/.agent/agent-memory/FixGoReleaserTagContext_temp.md
@@ -1,0 +1,12 @@
+# Temporary Plan: Fix GoReleaser Tag Context
+
+**Executed Date:** 2026-07-30
+**Purpose:** Update `.github/workflows/scripts/prepare-release-dir.sh` to ensure GoReleaser can correctly identify the current local tag (preventing `untagged` releases) and compare against previous tags (preventing full-history changelogs).
+
+## Checklist
+
+- [x] Modify `.github/workflows/scripts/prepare-release-dir.sh`:
+  - Remove the block of code that deletes local tags (`git tag | grep -v ... | xargs git tag -d`).
+  - Add `git fetch --tags origin || true` to guarantee all historical tags are present locally for GoReleaser's changelog boundaries.
+  - Add `git tag "${TAG}" HEAD -f` to explicitly materialize the local tag reference so GoReleaser knows exactly what version it is building.
+- [x] Ensure the script remains compliant with `shellcheck` standards.

--- a/.agent/agent-memory/PLAN_LOG.md
+++ b/.agent/agent-memory/PLAN_LOG.md
@@ -36,6 +36,10 @@
 - **Date:** 2026-07-30
 - **Purpose:** Create a dedicated GoReleaser configuration for the `manual-release.yml` workflow to prevent failures caused by missing release note files.
 
+## FixGoReleaserTagContext
+- **Date:** 2026-07-30
+- **Purpose:** Update `.github/workflows/scripts/prepare-release-dir.sh` to ensure GoReleaser can correctly identify the current local tag (preventing `untagged` releases) and compare against previous tags (preventing full-history changelogs).
+
 ## FixGoReleaserGPGMismatch
 - **Date:** 2026-07-29
 - **Purpose:** Resolve the release workflow failure (`gpg: error reading key: No secret key`) caused by GPG_KEY_ID pointing to an encryption-only subkey or being mismatched with the imported primary secret signing key.

--- a/.agent/plans/FixGoReleaserTagContext.md
+++ b/.agent/plans/FixGoReleaserTagContext.md
@@ -1,0 +1,22 @@
+# Plan: Fix GoReleaser Tag Context
+
+**Executed Date:** 2026-07-30
+**Purpose:** Update `.github/workflows/scripts/prepare-release-dir.sh` to ensure GoReleaser can correctly identify the current local tag (preventing `untagged` releases) and compare against previous tags (preventing full-history changelogs).
+
+## Background & Motivation
+The manual release workflow uses `actions/checkout` to clone the code into a subfolder (`tags/${TAG}`) for GoReleaser. However, `actions/checkout` in detached HEAD state does not automatically map the local git tag to the HEAD commit file reference. As a result, GoReleaser fails to determine the version context and defaults to creating a draft release named `untagged-*`. 
+
+Additionally, the `prepare-release-dir.sh` script previously contained a destructive cleanup block that aggressively deleted all local tags except the target release tag. This stripped away all historical tags (e.g., `v2.4.15`), leaving GoReleaser with no baseline to compare against. Assuming it was the very first release, GoReleaser compiled an exhaustive changelog of every commit since the beginning of the repository.
+
+## Proposed Solution
+We will update `.github/workflows/scripts/prepare-release-dir.sh` to properly provision the local Git environment for GoReleaser. First, we will remove the destructive tag-deletion block. Second, we will fetch all remote tags from origin to guarantee GoReleaser has a healthy historical baseline for changelog calculation. Finally, we will explicitly run `git tag "${TAG}" HEAD -f` to locally bind the tag to the HEAD commit. This action is purely local and ephemeral to the runner, but completely satisfies GoReleaser's version detection logic.
+
+## Implementation Steps
+
+1. **Update `prepare-release-dir.sh`:**
+   * Remove the `tags_to_delete` variable and its associated `xargs git tag -d` execution block.
+   * Inject a command to fetch all tags from the origin repository.
+   * Inject a command to forcefully tag `HEAD` with the `$TAG` environment variable.
+
+## Verification & Testing
+1. Run `shellcheck` on `.github/workflows/scripts/prepare-release-dir.sh` to verify syntax and style compliance.

--- a/.github/workflows/scripts/prepare-release-dir.sh
+++ b/.github/workflows/scripts/prepare-release-dir.sh
@@ -6,11 +6,13 @@ START_DIR="$(pwd)"
 
 cd "${WORKSPACE}/tags/${TAG}"
 
-# Remove local tags except for the targeted release tag to avoid GoReleaser confusion
-tags_to_delete=$(git tag | grep -v -e "^${TAG}$" || true)
-if [[ -n "${tags_to_delete}" ]]; then
-  echo "${tags_to_delete}" | xargs git tag -d
-fi
+# Fetch all tags from the remote origin so GoReleaser can find the previous tag for changelogs
+echo "Fetching all tags from remote origin..."
+git fetch origin --tags --quiet || true
+
+# Force tag HEAD with the current release tag locally so GoReleaser knows exactly what version it is building
+echo "Locally tagging HEAD with ${TAG}..."
+git tag "${TAG}" HEAD -f
 
 # Ensure manifest exists for the registry
 if [[ ! -f "terraform-registry-manifest.json" ]]; then

--- a/README.md
+++ b/README.md
@@ -77,3 +77,32 @@ make testacc
 ```
 
 To build, generate, and run all tests, run `make`.
+
+## Releasing Workflow Changes (Enterprise Security Compliance)
+
+Due to GitHub's server-side push validation and security model, the standard `GITHUB_TOKEN` is prevented from possessing `workflows: write` privileges. This means that if any release contains modifications to GitHub Actions workflow files (under `.github/workflows/`), automated pipelines (including `release-please` and `GoReleaser`) will be rejected by GitHub when attempting to create and push the release tag.
+
+Since development in this repository takes place on personal forks, maintainers releasing workflow changes must manually push the release tag to the official **upstream** repository from their local machine to bypass this restriction securely:
+
+1. **Manually Tag Main:**
+   ```shell
+   # 1. Add the upstream remote if you haven't already
+   git remote add upstream git@github.com:rancher/terraform-provider-file.git
+
+   # 2. Fetch latest changes from upstream
+   git fetch upstream
+
+   # 3. Create the tag locally pointing to upstream/main
+   git tag vX.Y.Z upstream/main
+
+   # 4. Push the tag directly to the upstream repository
+   git push upstream vX.Y.Z
+   ```
+
+2. **Merge the Release PR on GitHub.**
+
+3. **Everything works exactly like it should!**
+   - The automated `Release` workflow triggers on the merge push to the upstream `main` branch.
+   - `release-please` runs, detects the merged PR, and generates the perfect release notes.
+   - Since the tag already exists on `upstream`, the workflow **gracefully skips tag pushing** (preventing any GITHUB_TOKEN authentication failures).
+   - GoReleaser cleanly compiles the binaries, signs them with GPG, and publishes the official release with the perfect release-please notes under your manually created tag!

--- a/README.md
+++ b/README.md
@@ -106,3 +106,27 @@ Since development in this repository takes place on personal forks, maintainers 
    - `release-please` runs, detects the merged PR, and generates the perfect release notes.
    - Since the tag already exists on `upstream`, the workflow **gracefully skips tag pushing** (preventing any GITHUB_TOKEN authentication failures).
    - GoReleaser cleanly compiles the binaries, signs them with GPG, and publishes the official release with the perfect release-please notes under your manually created tag!
+
+### What if the release PR has already merged?
+
+You will need to use the manual release process, but again you will need to manually tag.
+
+1. **Manually Tag Main:**
+   ```shell
+   # 1. Add the upstream remote if you haven't already
+   git remote add upstream git@github.com:rancher/terraform-provider-file.git
+
+   # 2. Fetch latest changes from upstream
+   git fetch upstream
+
+   # 3. Create the tag locally pointing to upstream/main
+   git tag vX.Y.Z upstream/main
+
+   # 4. Push the tag directly to the upstream repository
+   git push upstream vX.Y.Z
+   ```
+
+2. **Trigger the "Manually Create Full Release" Workflow:**
+   Set the tag to the tag you created, set the sha to the sha of the tag.
+   GoReleaser will pick things up and create the release for you, but the release notes won't be as pretty.
+


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Release is failing: 

This process should resolve release issues, the release is failing to tag because the GitHub token it uses can't bypass GitHub's inherent restriction on workflow changes. The default GITHUB token, in any context, can't tag changes that have altered a workflow. There is no permission to grant the token, it simply can't.

The work-around, a maintainer must manually tag the main branch before merging the release PR.


## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
