### PR TITLE
fix: remove depth argument when looking for tag sha

### DIFF
--- a/.github/workflows/scripts/create-push-tag.sh
+++ b/.github/workflows/scripts/create-push-tag.sh
@@ -24,8 +24,9 @@ echo "Checking if tag ${TAG} exists..."
 if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1 || [[ -n "$(git ls-remote --tags origin "refs/tags/${TAG}" 2>/dev/null)" ]]; then
   echo "Tag ${TAG} already exists (locally or on remote). Verifying commit SHA..."
   
-  # Quietly fetch the tag ref from remote if we don't have it locally or to ensure it's up to date
-  git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --depth=1 --no-tags --quiet || true
+  # Quietly fetch the tag ref from remote if we don't have it locally or to ensure it's up to date.
+  # We do not use --depth=1 as shallow fetching a tag ref directly is unsupported on some Git servers/versions.
+  git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --no-tags --quiet || true
   
   existing_sha=$(git rev-list -n 1 "${TAG}")
   target_sha=$(git rev-list -n 1 "${SHA}")


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Release is failing: https://github.com/rancher/terraform-provider-file/actions/runs/30519120337/job/90795419427

fix: resolve shallow fetch failures on lightweight tags

This change removes the --depth=1 parameter from the git fetch command inside create-push-tag.sh.

### Why this is necessary:

Our tag-matching script performs a local SHA verification if a tag already exists. To do this, it quietly fetches the tag ref from the remote. However, because our tags are lightweight tags (which point directly to a commit object rather than a dedicated tag object), performing a shallow fetch (--depth=1) of the tag ref directly is unsupported by GitHub's Git server, returning fatal: couldn't find remote ref.

Removing --depth=1 converts the fetch to a standard, lightweight single-ref fetch. This is fully supported, succeeds cleanly on Git 2.55.0, and ensures the tag is pulled locally so git rev-list can resolve and validate the SHA without crashing.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint, shellcheck

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
