### PR TITLE
fix: add retry and backoff logic when publishing releases

### DIFF
--- a/.github/workflows/scripts/publish-release.js
+++ b/.github/workflows/scripts/publish-release.js
@@ -6,15 +6,32 @@ export default async ({ github, context, core, process }) => {
     }
     const tag = version.startsWith('v') ? version : `v${version}`;
 
-    core.info(`Listing releases to find tag ${tag}...`);
-    const releases = await github.paginate(github.rest.repos.listReleases, {
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-    });
+    let release;
+    const maxRetries = 5;
+    const baseDelayMs = 2000; // Start with a 2-second delay
 
-    const release = releases.find(r => r.tag_name === tag);
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      core.info(`Listing releases to find tag ${tag} (Attempt ${attempt}/${maxRetries})...`);
+      const releases = await github.paginate(github.rest.repos.listReleases, {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        per_page: 100,
+      });
+
+      release = releases.find(r => r.tag_name === tag);
+      if (release) {
+        break;
+      }
+
+      if (attempt < maxRetries) {
+        const delay = baseDelayMs * Math.pow(2, attempt - 1);
+        core.info(`Release not found yet. Retrying in ${delay}ms...`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+
     if (!release) {
-      core.setFailed(`Could not find release for tag ${tag}`);
+      core.setFailed(`Could not find release for tag ${tag} after ${maxRetries} attempts.`);
       return;
     }
 
@@ -24,7 +41,8 @@ export default async ({ github, context, core, process }) => {
         owner: context.repo.owner,
         repo: context.repo.repo,
         release_id: release.id,
-        draft: false
+        draft: false,
+        make_latest: tag.includes('-rc.') ? "false" : "true"
       });
       core.info(`Successfully published release for tag ${tag}`);
     } else {


### PR DESCRIPTION
# Description
<!--- Describe your change and how it addresses the issue linked above. --->
Release is failing: https://github.com/rancher/terraform-provider-file/actions/runs/30522773704/job/90806709507

There could be a delay between when Goreleaser generates a draft release and it is able to be found on the API.
This adds a retry and backoff loop to the draft publish logic.


## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
