### PR TITLE
ci: reconcile release-please pr labels after merge

### DIFF
--- a/.agent/plans/ReleaseProcess.md
+++ b/.agent/plans/ReleaseProcess.md
@@ -1,6 +1,6 @@
 # Plan: Release Process
 
-* **Executed Date:** pending
+* **Executed Date:** 2026-08-05
 * **Purpose:** Establish and enable the newly designed "Standard Repository Release Process: Architectural Blueprint & Tooling Specification" as our repository's standard. This involves documenting the standard in `RELEASING.md`, communicating it in `README.md`, and making the necessary codebase updates to convert our GHA and script logic to this new process.
 * **Goals & Code Snippets:**
 

--- a/.agent/plans/ReleaseProcess.md
+++ b/.agent/plans/ReleaseProcess.md
@@ -1,6 +1,6 @@
 # Plan: Release Process
 
-* **Executed Date:** 2026-08-05
+* **Executed Date:** pending
 * **Purpose:** Establish and enable the newly designed "Standard Repository Release Process: Architectural Blueprint & Tooling Specification" as our repository's standard. This involves documenting the standard in `RELEASING.md`, communicating it in `README.md`, and making the necessary codebase updates to convert our GHA and script logic to this new process.
 * **Goals & Code Snippets:**
 
@@ -93,6 +93,7 @@ This swimlane diagram traces the detailed event triggers and data flow between d
 |                                             |           - Keyring Workaround: Dynamically parses primary ID  |
 |                                             |           - Nix: GoReleaser cross-compiles stable binaries     |
 |                                             |           - Action: Publishes Final GPG-Signed Release         |
+|                                             |           - Action: Reconciles Release PR labels in GitHub     |
 |                                             |                                                                |
 ```
 
@@ -190,6 +191,7 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 * **Tagged vX.Y.Z:** `Release Please` registers the release merge and automatically creates and pushes the official semantic git tag.
 * **Key Extracted:** The workflow imports the signing GPG block from Vault and dynamically queries the keyring to extract the actual primary secret key ID to work around subkey/mismatch weirdness.
 * **Signed & Published:** GoReleaser compiles binaries inside the reproducibly locked Nix environment, signs them with the GPG key, and publishes the signed provider assets directly to the GitHub Release.
+* **Label Reconciliation:** Since `skip-github-release: true` is configured in `release-please-config.json` to let GoReleaser manage the release, `release-please` skips post-merge tagging/labeling actions. To prevent release PRs from being left with outdated/pending labels, the publish-release script automatically reconciles labels on the merged Release PR (removing `autorelease: pending` and `ready-to-merge`, and adding `autorelease: tagged`).
 
 ---
 
@@ -237,3 +239,11 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 - [x] Remove redundant, false-failing `verify-pr-requirements` job from `pull_request.yaml` to improve developer UX and prevent premature check failures.
 - [x] Implement robust GitHub CLI and native auto-merge pipeline (`gh pr merge --auto`) with direct merge and REST API fallbacks in `verify-pr-requirements.mjs`.
 - [x] Verify updated code locally and obtain approval.
+
+### Sub-task: Reconcile Release PR Labels after Merge
+- [x] Implement label reconciliation logic inside `.github/workflows/scripts/publish-release.js` to find the merged Release PR and update its labels (remove `autorelease: pending` and `ready-to-merge`, add `autorelease: tagged`).
+- [x] Run `node --check` to verify that `.github/workflows/scripts/publish-release.js` syntax remains valid.
+- [x] Run `actionlint` locally to verify that `.github/workflows/release.yml` syntax remains valid.
+- [x] Enter Proactive Review Mode on the written code diff to proactively resolve any issues human or Copilot automated reviews might flag.
+- [x] Present the unstaged diff to the developer in the chat and request their IDE review.
+- [ ] Commit changes locally with a conventional prefix (e.g., `ci: reconcile release-please pr labels after merge`) and `APPROVED_BY_USER=1`.

--- a/.agent/plans/ReleaseProcess.md
+++ b/.agent/plans/ReleaseProcess.md
@@ -246,4 +246,4 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 - [x] Run `actionlint` locally to verify that `.github/workflows/release.yml` syntax remains valid.
 - [x] Enter Proactive Review Mode on the written code diff to proactively resolve any issues human or Copilot automated reviews might flag.
 - [x] Present the unstaged diff to the developer in the chat and request their IDE review.
-- [ ] Commit changes locally with a conventional prefix (e.g., `ci: reconcile release-please pr labels after merge`) and `APPROVED_BY_USER=1`.
+- [x] Commit changes locally with a conventional prefix (e.g., `ci: reconcile release-please pr labels after merge`) and `APPROVED_BY_USER=1`.

--- a/.github/workflows/scripts/publish-release.js
+++ b/.github/workflows/scripts/publish-release.js
@@ -48,6 +48,70 @@ export default async ({ github, context, core, process }) => {
     } else {
       core.info(`Release for tag ${tag} is already published.`);
     }
+
+    // -------------------------------------------------------------
+    // PR Label Reconciliation
+    // -------------------------------------------------------------
+    try {
+      core.info(`Finding pull requests associated with commit ${context.sha}...`);
+      const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        commit_sha: context.sha,
+      });
+
+      const pr = prs.data.find(p => p.state === 'closed' && p.merged_at);
+      if (pr) {
+        core.info(`Found associated merged PR #${pr.number}: "${pr.title}"`);
+        
+        const isReleasePlease = pr.head.ref === 'release-please--branches--main' || pr.head.ref?.startsWith('release-please');
+        if (isReleasePlease) {
+          core.info(`PR #${pr.number} is a release-please PR. Reconciling labels...`);
+          
+          const labels = pr.labels.map(l => l.name);
+          core.info(`Current labels on PR #${pr.number}: ${labels.join(', ')}`);
+
+          const labelsToRemove = ['autorelease: pending', 'ready-to-merge'];
+          for (const label of labelsToRemove) {
+            if (labels.includes(label)) {
+              core.info(`Removing label "${label}" from PR #${pr.number}...`);
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label,
+                });
+                core.info(`Successfully removed label "${label}".`);
+              } catch (err) {
+                core.warning(`Failed to remove label "${label}": ${err.message}`);
+              }
+            }
+          }
+
+          if (!labels.includes('autorelease: tagged')) {
+            core.info(`Adding label "autorelease: tagged" to PR #${pr.number}...`);
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: ['autorelease: tagged'],
+              });
+              core.info(`Successfully added label "autorelease: tagged".`);
+            } catch (err) {
+              core.warning(`Failed to add label "autorelease: tagged": ${err.message}`);
+            }
+          }
+        } else {
+          core.info(`PR #${pr.number} is not a release-please PR.`);
+        }
+      } else {
+        core.info(`No merged pull request associated with commit ${context.sha} was found.`);
+      }
+    } catch (labelError) {
+      core.warning(`Failed to reconcile PR labels: ${labelError.message}`);
+    }
   } catch (error) {
     core.setFailed(`Failed to publish release: ${error.message}`);
   }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,6 +85,7 @@ This swimlane diagram traces the detailed event triggers and data flow between d
 |                                             |           - Keyring Workaround: Dynamically parses primary ID  |
 |                                             |           - Nix: GoReleaser cross-compiles stable binaries     |
 |                                             |           - Action: Publishes Final GPG-Signed Release         |
+|                                             |           - Action: Reconciles Release PR labels in GitHub     |
 |                                             |                                                                |
 ```
 
@@ -182,3 +183,4 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 * **Tagged vX.Y.Z:** `Release Please` registers the release merge and automatically creates and pushes the official semantic git tag.
 * **Key Extracted:** The workflow imports the signing GPG block from Vault and dynamically queries the keyring to extract the actual primary secret key ID to work around subkey/mismatch weirdness.
 * **Signed & Published:** GoReleaser compiles binaries inside the reproducibly locked Nix environment, signs them with the GPG key, and publishes the signed provider assets directly to the GitHub Release.
+* **Label Reconciliation:** Since `skip-github-release: true` is configured in `release-please-config.json` to let GoReleaser manage the release, `release-please` skips post-merge tagging/labeling actions. To prevent release PRs from being left with outdated/pending labels, the publish-release script automatically reconciles labels on the merged Release PR (removing `autorelease: pending` and `ready-to-merge`, and adding `autorelease: tagged`).


### PR DESCRIPTION
### Description
This PR resolves the issue where release-please PR labels are not reconciled after a merge completes. Because we utilize `"skip-github-release": true` in `release-please-config.json` to allow GoReleaser to manage tagging and publishing, release-please skips its standard post-merge tagging and labeling step. 

This change enhances `.github/workflows/scripts/publish-release.js` to:
1. Dynamically locate the closed and merged Pull Request associated with the commit SHA.
2. Verify if the merged PR originates from release-please.
3. Automatically remove the `autorelease: pending` and `ready-to-merge` labels.
4. Automatically add the `autorelease: tagged` label.

This maintains a perfectly clean PR label history and avoids outstanding pending labels on closed release PRs.

### Testing & Validation
- Verified syntax via `node --check .github/workflows/scripts/publish-release.js`.
- Verified GHA workflow configuration syntax via `actionlint .github/workflows/release.yml`.
- Standard development process plan and `RELEASING.md` updated and synchronized.