### PR TITLE
ci: enable automated fork PR merging via Ruleset bypass

### DIFF
--- a/.agent/agent-memory/WorkflowExecutionProtections.md
+++ b/.agent/agent-memory/WorkflowExecutionProtections.md
@@ -41,11 +41,13 @@ Because protections are built on top of the GitHub Rulesets framework, they inhe
 
 ## 4. Supported Policy Rule Options
 
-Unlike branch-specific rulesets, Actions policies apply repository-wide and do not target specific branches. There are exactly **three available options/rules** in this policy interface:
+> 💡 **Maintainer Note:** Because this feature is currently in public preview, these details and options are subject to change by GitHub. Always refer to the [authoritative GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/actions-policies/workflow-execution-protections) for the most up-to-date information.
+
+As of **August 2026**, the Actions Policies user interface exposes **three primary options/rules** for configuring protections:
 
 ### A. Restrict Actors (Who can trigger workflows)
-Controls which identities are allowed to trigger workflow runs. By default, any user with write access can trigger workflows. This separates the privilege of pushing code from the privilege of executing CI.
-* **Supported Actor Types:**
+Controls which identities are allowed to trigger workflow runs. This separates the privilege of pushing code from the privilege of executing CI, preventing unreviewed/untrusted contributions from executing actions.
+* **Supported Actor Types (as of August 2026):**
   * Individual GitHub Users
   * Repository Roles (e.g., `Read`, `Maintain`, `Admin`, `Triage`)
   * Installed GitHub Apps (including the system-level **GitHub Actions** App for GITHUB_TOKEN pushes)
@@ -53,8 +55,8 @@ Controls which identities are allowed to trigger workflow runs. By default, any 
   * Dependabot (`dependabot[bot]`)
 
 ### B. Restrict Events (Which events can trigger workflows)
-Declares exactly which GHA events are permitted to trigger runs.
-* **Supported Events:**
+Declares exactly which GitHub Actions webhook events are permitted to trigger runs on the repository.
+* **Supported Events (as of August 2026):**
   * `push`
   * `pull_request`
   * `pull_request_target`

--- a/.agent/agent-memory/WorkflowExecutionProtections.md
+++ b/.agent/agent-memory/WorkflowExecutionProtections.md
@@ -1,0 +1,94 @@
+# GitHub Actions Policies & Workflow Execution Protections
+
+* **Source Documentation:** 
+  - [About Actions Policies](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/actions-policies/about-actions-policies)
+  - [Workflow Execution Protections](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/actions-policies/workflow-execution-protections)
+* **Status:** Public Preview (As of June/July 2026)
+
+---
+
+## 1. Context & Architectural Overview
+
+GitHub Actions Policies and Workflow Execution Protections introduce a centralized, platform-level governance layer to GitHub Actions. This closes a critical security vector and provides administrators with a declarative way to restrict workflow execution.
+
+Previously, workflow execution was dictated strictly by the YAML definitions found within the triggering commit/ref. A malicious actor with write access (or via an unreviewed fork PR) could manipulate a workflow file to run arbitrary code with privileged tokens. This new policies framework shifts the trust boundary from the distributed, easily compromised codebase up to a centralized repository/organization ruleset.
+
+---
+
+## 2. Core Concepts
+
+### Actions Policies
+A dedicated administration interface separate from the existing *Actions > General* settings. It is designed to host multiple governance policies over time. Currently, **Workflow Execution Protections** is the primary policy type available.
+
+### Workflow Execution Protections
+An allowlist mechanism configured via GitHub Rulesets that acts as a gatekeeper *prior* to a workflow run starting. When an event occurs, GitHub evaluates the configured ruleset. If the event or the actor who initiated it is not permitted, the workflow execution is blocked before any runner is provisioned or code is executed.
+
+---
+
+## 3. Ruleset Features & Configurations
+
+Because protections are built on top of the GitHub Rulesets framework, they inherit several advanced enterprise-grade controls:
+
+### Targeting & Scoping
+* **Multi-Level Enforcement:** Policies can be established and enforced at the **Enterprise**, **Organization**, or individual **Repository** levels.
+* **Custom Property Scoping:** Organizations can target rulesets to groups of repositories dynamically using **Repository Custom Properties** (e.g., applying strict protections only to repositories marked as `public` or `tier-1`).
+
+### Deployment Modes
+* **Active:** Enforces the policies immediately, blocking unauthorized events/actors.
+* **Evaluate Mode:** Runs the policies in a passive "shadow" mode. Blocked workflows are logged in Policy Insights and audit logs, but execution is not halted. This allows administrators to safely test and audit policies before active enforcement.
+
+---
+
+## 4. Supported Policy Rule Options
+
+Unlike branch-specific rulesets, Actions policies apply repository-wide and do not target specific branches. There are exactly **three available options/rules** in this policy interface:
+
+### A. Restrict Actors (Who can trigger workflows)
+Controls which identities are allowed to trigger workflow runs. By default, any user with write access can trigger workflows. This separates the privilege of pushing code from the privilege of executing CI.
+* **Supported Actor Types:**
+  * Individual GitHub Users
+  * Repository Roles (e.g., `Read`, `Maintain`, `Admin`, `Triage`)
+  * Installed GitHub Apps (including the system-level **GitHub Actions** App for GITHUB_TOKEN pushes)
+  * GitHub Copilot
+  * Dependabot (`dependabot[bot]`)
+
+### B. Restrict Events (Which events can trigger workflows)
+Declares exactly which GHA events are permitted to trigger runs.
+* **Supported Events:**
+  * `push`
+  * `pull_request`
+  * `pull_request_target`
+  * `workflow_dispatch`
+
+### C. Require Lockfile
+Enforces strict locking requirements on configuration files (e.g., locking down workflow configurations or package dependencies) to prevent accidental or malicious modifications during execution.
+
+---
+
+## 5. Security & Threat Mitigations
+
+Workflow execution protections are highly effective at disrupting several common pipeline attacks:
+
+| Attack Vector | Threat Description | Ruleset Mitigation Strategy |
+| :--- | :--- | :--- |
+| **Poisoned Pipeline Execution (PPE)** | Attackers submit a PR from a fork modifying workflow files or exploiting `pull_request_target` to execute malicious code in the privileged base context. | Use **Restrict Events** to prohibit or limit `pull_request_target` runs. |
+| **Manual-Trigger Abuse** | Non-maintainer contributors with write access invoke sensitive deployment/release pipelines manually. | Use **Restrict Actors** to limit `workflow_dispatch` to specific roles (e.g. `Maintain` or `Admin`). |
+| **Untrusted Actor Runs** | External contributors or compromised integration tokens trigger costly automated runs. | Use **Restrict Actors** to block low-trust identities or unauthorized bots from initiating any workflow execution. |
+| **Workflow File Tampering** | Attackers bypass file-level branch protection rules (like CODEOWNERS) to force-execute compromised workflows. | Centralized repository policies override any configuration declared in the local workspace YAML files. |
+
+---
+
+## 6. Setup and Administration Instructions
+
+To configure these protections in GitHub:
+
+1. Navigate to your repository on GitHub.
+2. Under the repository name, click **Settings**.
+3. In the left sidebar, locate the **Actions** section and click **Policies**.
+4. Create a new ruleset under the Policies screen (note: this applies globally to the repository; there is **no branch selector**).
+5. Add and configure the desired rules:
+   * **Restrict Actors** (e.g., add the **GitHub Actions** App or write-level roles to allow GITHUB_TOKEN pushes to trigger downstream release workflows).
+   * **Restrict Events** (e.g., permit **`push`** to enable release pipelines, while restricting dangerous events).
+   * **Require Lockfile** (to secure execution state).
+6. Select your enforcement status (**Evaluate** to test, **Active** to enforce).
+7. Click **Create** or **Save changes**.

--- a/.agent/plans/ReleaseProcess.md
+++ b/.agent/plans/ReleaseProcess.md
@@ -258,9 +258,9 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 - [x] Push the branch to the user's origin fork and generate a Draft PR using `create-pr.sh`.
 
 ### Phase 9: Resolve Copilot PR Review Feedback
-- [ ] Refactor `verify-pr-requirements.mjs` to pass `isFork` to `mergePullRequest`.
-- [ ] Update `mergePullRequest` with a graceful merge-failure fallback: if the merge fails, apply/keep the `ready-to-merge` label and post a detailed diagnostic comment explaining how the maintainer can merge or fix the Ruleset.
-- [ ] Rephrase `ReleaseProcess.md` to add a clear, explicit checklist of the repository settings and ruleset prerequisite options needed to enable direct auto-merges of fork PRs.
-- [ ] Update `WorkflowExecutionProtections.md` to explicitly time-bound its product claims as of August 2026, and add prominent links to the authoritative GitHub documentation pages.
-- [ ] Compile and verify the refactored script with `node --check`.
+- [x] Refactor `verify-pr-requirements.mjs` to pass `isFork` to `mergePullRequest`.
+- [x] Update `mergePullRequest` with a graceful merge-failure fallback: if the merge fails, apply/keep the `ready-to-merge` label and post a detailed diagnostic comment explaining how the maintainer can merge or fix the Ruleset.
+- [x] Rephrase `ReleaseProcess.md` to add a clear, explicit checklist of the repository settings and ruleset prerequisite options needed to enable direct auto-merges of fork PRs.
+- [x] Update `WorkflowExecutionProtections.md` to explicitly time-bound its product claims as of August 2026, and add prominent links to the authoritative GitHub documentation pages.
+- [x] Compile and verify the refactored script with `node --check`.
 

--- a/.agent/plans/ReleaseProcess.md
+++ b/.agent/plans/ReleaseProcess.md
@@ -179,6 +179,12 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 
 ---
 
+### **Phase 3b: Direct Fork PR Auto-Merge (The Ruleset Bypass)**
+* **Fork PR Evaluation:** When `pr-executor.yml` (running under `workflow_run`) evaluates a fork PR, it has full write/merge privileges on the base repository. If all requirements are met, it executes the native squash-merge using the GitHub CLI (`gh pr merge --auto --squash`).
+* **The Recursion Bypass:** Normally, a GITHUB_TOKEN push (or merge) event prevents downstream workflows (such as Release Please) from triggering due to recursion prevention rules. However, the repository utilizes **GitHub Workflow Execution Protections (Rulesets)** to explicitly allow `github-actions[bot]` to trigger push-based workflows on `main`, ensuring downstream release pipelines run seamlessly.
+
+---
+
 ### **Phase 4: Release Management & The Integration Test Gate (GATES)**
 * **Release PR Maintained:** Merging into `main` triggers `Release Please`. It calculates the next version and automatically updates a draft "Release PR" containing updated version coordinates and changelogs.
 * **Integration Tests Gate:** The Release PR acts as a staging queue where a dedicated CI workflow executes the **full integration and acceptance test suite** (using real cloud resources/relays). Merging is blocked until this suite passes.
@@ -237,3 +243,11 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 - [x] Remove redundant, false-failing `verify-pr-requirements` job from `pull_request.yaml` to improve developer UX and prevent premature check failures.
 - [x] Implement robust GitHub CLI and native auto-merge pipeline (`gh pr merge --auto`) with direct merge and REST API fallbacks in `verify-pr-requirements.mjs`.
 - [x] Verify updated code locally and obtain approval.
+
+### Phase 8: Direct Fork PR Auto-Merge (Ruleset Enabled)
+- [x] Refactor `.github/workflows/scripts/verify-pr-requirements.mjs` to completely remove the legacy `isFork` blocker, allowing fork PRs to be merged directly by the executor just like local and Dependabot PRs.
+- [x] Run `node --check` to verify `.github/workflows/scripts/verify-pr-requirements.mjs` syntax.
+- [ ] Present the unstaged diff to the developer in the chat.
+- [ ] Solicit manual developer review and obtain explicit approval in the chat.
+- [ ] Stage the modified/created files and commit locally with a conventional prefix (e.g. `ci: enable automated fork PR merging via Ruleset bypass`) and `APPROVED_BY_USER=1`.
+- [ ] Push the branch to the user's origin fork and generate a Draft PR using `create-pr.sh`.

--- a/.agent/plans/ReleaseProcess.md
+++ b/.agent/plans/ReleaseProcess.md
@@ -182,6 +182,11 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 ### **Phase 3b: Direct Fork PR Auto-Merge (The Ruleset Bypass)**
 * **Fork PR Evaluation:** When `pr-executor.yml` (running under `workflow_run`) evaluates a fork PR, it has full write/merge privileges on the base repository. If all requirements are met, it executes the native squash-merge using the GitHub CLI (`gh pr merge --auto --squash`).
 * **The Recursion Bypass:** Normally, a GITHUB_TOKEN push (or merge) event prevents downstream workflows (such as Release Please) from triggering due to recursion prevention rules. However, the repository utilizes **GitHub Workflow Execution Protections (Rulesets)** to explicitly allow `github-actions[bot]` to trigger push-based workflows on `main`, ensuring downstream release pipelines run seamlessly.
+* **🔧 Ruleset Configuration Prerequisites & Guardrails:**
+  * **Location:** Repository settings -> *Actions > Policies*.
+  * **Restrict Events:** Permit the **`push`** event to trigger actions (so the squash-merge commit on `main` initiates downstream release workflows). Keep other high-risk events (like `pull_request_target`) strictly restricted.
+  * **Restrict Actors:** Add the system-level **`GitHub Actions` App** (representing the GITHUB_TOKEN) and your team's authorized roles (like `Write`, `Maintain`, `Admin` or the `k3s` group) as allowed actors to trigger the `push` event.
+  * **Scope:** Ensure this ruleset is active on the repository (Actions Policies apply globally and do not use branch selectors).
 
 ---
 
@@ -247,7 +252,15 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 ### Phase 8: Direct Fork PR Auto-Merge (Ruleset Enabled)
 - [x] Refactor `.github/workflows/scripts/verify-pr-requirements.mjs` to completely remove the legacy `isFork` blocker, allowing fork PRs to be merged directly by the executor just like local and Dependabot PRs.
 - [x] Run `node --check` to verify `.github/workflows/scripts/verify-pr-requirements.mjs` syntax.
-- [ ] Present the unstaged diff to the developer in the chat.
-- [ ] Solicit manual developer review and obtain explicit approval in the chat.
-- [ ] Stage the modified/created files and commit locally with a conventional prefix (e.g. `ci: enable automated fork PR merging via Ruleset bypass`) and `APPROVED_BY_USER=1`.
-- [ ] Push the branch to the user's origin fork and generate a Draft PR using `create-pr.sh`.
+- [x] Present the unstaged diff to the developer in the chat.
+- [x] Solicit manual developer review and obtain explicit approval in the chat.
+- [x] Stage the modified/created files and commit locally with a conventional prefix (e.g. `ci: enable automated fork PR merging via Ruleset bypass`) and `APPROVED_BY_USER=1`.
+- [x] Push the branch to the user's origin fork and generate a Draft PR using `create-pr.sh`.
+
+### Phase 9: Resolve Copilot PR Review Feedback
+- [ ] Refactor `verify-pr-requirements.mjs` to pass `isFork` to `mergePullRequest`.
+- [ ] Update `mergePullRequest` with a graceful merge-failure fallback: if the merge fails, apply/keep the `ready-to-merge` label and post a detailed diagnostic comment explaining how the maintainer can merge or fix the Ruleset.
+- [ ] Rephrase `ReleaseProcess.md` to add a clear, explicit checklist of the repository settings and ruleset prerequisite options needed to enable direct auto-merges of fork PRs.
+- [ ] Update `WorkflowExecutionProtections.md` to explicitly time-bound its product claims as of August 2026, and add prominent links to the authoritative GitHub documentation pages.
+- [ ] Compile and verify the refactored script with `node --check`.
+

--- a/.agent/plans/ReleaseProcess.md
+++ b/.agent/plans/ReleaseProcess.md
@@ -264,3 +264,5 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 - [x] Update `WorkflowExecutionProtections.md` to explicitly time-bound its product claims as of August 2026, and add prominent links to the authoritative GitHub documentation pages.
 - [x] Compile and verify the refactored script with `node --check`.
 
+<!-- Retrigger workflows -->
+

--- a/.agent/plans/ReleaseProcess.md
+++ b/.agent/plans/ReleaseProcess.md
@@ -263,6 +263,7 @@ This guarantees that GPG signing never fails due to subkey mismatches, whitespac
 - [x] Rephrase `ReleaseProcess.md` to add a clear, explicit checklist of the repository settings and ruleset prerequisite options needed to enable direct auto-merges of fork PRs.
 - [x] Update `WorkflowExecutionProtections.md` to explicitly time-bound its product claims as of August 2026, and add prominent links to the authoritative GitHub documentation pages.
 - [x] Compile and verify the refactored script with `node --check`.
+- [x] Prevent throwing restError in the fork graceful fallback path to keep the PR status check green, enabling manual maintainer merge.
 
 <!-- Retrigger workflows -->
 

--- a/.agent/skills/get-pr-comments.sh
+++ b/.agent/skills/get-pr-comments.sh
@@ -101,8 +101,8 @@ get_repo_context() {
 
     # If no upstream, default to canonical rancher repository
     if [[ -z "${url}" ]]; then
-        echo "rancher/terraform-provider-rancher2"
-        return
+      echo "rancher/terraform-provider-file"
+      return
     fi
 
     local clean_url="${url}"

--- a/.github/workflows/scripts/verify-pr-requirements.mjs
+++ b/.github/workflows/scripts/verify-pr-requirements.mjs
@@ -605,6 +605,8 @@ ${restError.message}
           } catch (fallbackError) {
             core.error(`Graceful fallback failed: ${fallbackError.message}`);
           }
+          core.warning(`Fork PR merge failed but graceful fallback was executed successfully. Returning gracefully to prevent blocking manual maintainer merge.`);
+          return;
         }
         throw restError;
       }

--- a/.github/workflows/scripts/verify-pr-requirements.mjs
+++ b/.github/workflows/scripts/verify-pr-requirements.mjs
@@ -94,7 +94,7 @@ export default async ({ github, context, core, process }) => {
                 // Ignore removal failure
               }
             }
-            await mergePullRequest({ github, core, owner, repo, prNumber: pr.number, sha: pr.head.sha });
+            await mergePullRequest({ github, core, owner, repo, prNumber: pr.number, sha: pr.head.sha, isFork });
           }
         } else {
           // Requirements are not met. If the PR has the "ready-to-merge" label, remove it!
@@ -460,7 +460,7 @@ async function deleteBotCommentIfExists({ github, core, owner, repo, prNumber })
 /**
  * Executes squash-merge on the PR, dynamically generating a clean Conventional Commit message via Copilot.
  */
-async function mergePullRequest({ github, core, owner, repo, prNumber, sha }) {
+async function mergePullRequest({ github, core, owner, repo, prNumber, sha, isFork }) {
   core.info(`Fetching PR #${prNumber} changed files list to evaluate product scope...`);
   const files = await withRetry(core, () => github.paginate(github.rest.pulls.listFiles, {
     owner,
@@ -565,8 +565,49 @@ async function mergePullRequest({ github, core, owner, repo, prNumber, sha }) {
       core.info(`PR #${prNumber} merged directly via gh CLI successfully!`);
     } catch (directError) {
       core.warning(`Failed direct merge via gh CLI: ${directError.message}. Retrying REST API merge...`);
-      await withRetry(core, () => github.rest.pulls.merge(mergeParams));
-      core.info(`PR #${prNumber} merged via REST API successfully!`);
+      try {
+        await withRetry(core, () => github.rest.pulls.merge(mergeParams));
+        core.info(`PR #${prNumber} merged via REST API successfully!`);
+      } catch (restError) {
+        core.error(`All merge attempts failed for PR #${prNumber}: ${restError.message}`);
+        
+        if (isFork) {
+          core.info(`Fork PR merge failed. Executing graceful fallback: applying 'ready-to-merge' label and posting maintainer notification.`);
+          try {
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: ['ready-to-merge'],
+            });
+            const fallbackMsg = `### 🤖 Automated Merge Failed (Permission Barrier)
+
+This PR has successfully passed all quality gates, but the automated merge attempt failed with the following error:
+\`\`\`text
+${restError.message}
+\`\`\`
+
+**Possible Causes:**
+1. The required GitHub Actions Workflow Ruleset has not been created or is misconfigured.
+2. The GITHUB_TOKEN has not been authorized to bypass GActions recursion protections.
+
+**How to Resolve:**
+* A repository maintainer can click **Merge** manually on this PR.
+* Alternatively, ensure the Ruleset is active on \`main\` with **Restrict Actors** allowing the **GitHub Actions App** to bypass push protections.`;
+            await updateOrPostComment({
+              github,
+              core,
+              owner,
+              repo,
+              prNumber,
+              message: fallbackMsg,
+            });
+          } catch (fallbackError) {
+            core.error(`Graceful fallback failed: ${fallbackError.message}`);
+          }
+        }
+        throw restError;
+      }
     }
   }
 }

--- a/.github/workflows/scripts/verify-pr-requirements.mjs
+++ b/.github/workflows/scripts/verify-pr-requirements.mjs
@@ -78,32 +78,8 @@ export default async ({ github, context, core, process }) => {
                 labels: ['ready-to-merge'],
               });
             }
-          } else if (isFork) {
-            core.info(`PR #${pr.number} is from a fork. GITHUB_TOKEN lacks merge permissions on fork PRs. Labeling and posting comment instead...`);
-            if (!hasReadyLabel) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: pr.number,
-                labels: ['ready-to-merge'],
-              });
-            }
-            const readyMsg = `### 🤖 PR Ready to Merge
-
-This PR has successfully passed all quality gates, lints, commit signatures, and approvals!
-Because this PR originates from a **forked repository**, GitHub Actions lacks the write-level merge permissions required to merge it automatically.
-
-A repository maintainer must click **Merge** manually on this PR.`;
-            await updateOrPostComment({
-              github,
-              core,
-              owner,
-              repo,
-              prNumber: pr.number,
-              message: readyMsg,
-            });
           } else {
-            // Local/Dependabot PR -> Merge automatically!
+            // Merge automatically (including fork PRs)!
             await deleteBotCommentIfExists({ github, core, owner, repo, prNumber: pr.number });
             if (hasReadyLabel) {
               // Remove the label before merging to keep history clean


### PR DESCRIPTION
Enables automated fork PR merges securely using Workflow Execution Protections rulesets, removing the legacy manual merge blocker.